### PR TITLE
Update IBM.MQ.xml

### DIFF
--- a/IBM.MQ.xml
+++ b/IBM.MQ.xml
@@ -1,102 +1,101 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
 <ManagementPack ContentReadable="true" SchemaVersion="2.0" OriginalSchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<Manifest>
-		<Identity>
-			<ID>IBM.MQ</ID>
-			<Version>3.2.1.6</Version>
-		</Identity>
-		<Name>IBM.MQ</Name>
-		<References>
-			<Reference Alias="SC">
-				<ID>Microsoft.SystemCenter.Library</ID>
-				<Version>7.0.8433.0</Version>
-				<PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
-			</Reference>
-			<Reference Alias="Windows">
-				<ID>Microsoft.Windows.Library</ID>
-				<Version>7.5.8501.0</Version>
-				<PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
-			</Reference>
-			<Reference Alias="System">
-				<ID>System.Library</ID>
-				<Version>7.5.8501.0</Version>
-				<PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
-			</Reference>			
-			<Reference Alias="Health">
-				<ID>System.Health.Library</ID>
-				<Version>7.0.8433.0</Version>
-				<PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
-			</Reference>
-		    <Reference Alias="Perf">
-			  <ID>System.Performance.Library</ID>
-			  <Version>7.0.8433.0</Version>
-			  <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
-		    </Reference>
-			<Reference Alias="MSDL">
-				<ID>Microsoft.SystemCenter.DataWarehouse.Library</ID>
-				<Version>7.1.10226.0</Version>
-				<PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
-			</Reference>		  
-		</References>
-	</Manifest>
-	<TypeDefinitions>
-		<EntityTypes>
-			<ClassTypes>
-				<ClassType ID="IBM.MQ.Channel" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
-					<Property ID="ChannelName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-					<Property ID="ChannelType" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-					<Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-				</ClassType>
-				<ClassType ID="IBM.MQ.Listener" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
-					<Property ID="ListenerName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-					<Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-				</ClassType>
-				<ClassType ID="IBM.MQ.Queue" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
-					<Property ID="DESCR" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-					<Property ID="MAXDEPTH" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-					<Property ID="MAXMSGL" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-					<Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-					<Property ID="QueueName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-					<Property ID="TYPE" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-				</ClassType>
-				<ClassType ID="IBM.MQ.QueueManager" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
-					<Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-				</ClassType>
-				<ClassType ID="IBM.MQ.Server" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.LocalApplication" Hosted="true" Singleton="false" Extension="false">
-					<Property ID="Version" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-					<Property ID="InstallPath" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-				</ClassType>				
-			</ClassTypes>			
-			<RelationshipTypes>
-				<RelationshipType ID="IBM.MQ.Server.Hosts.QueueManager" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
-					<Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Server" />
-					<Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
-				</RelationshipType>
-				<RelationshipType ID="IBM.MQ.QueueManager.Hosts.Channel" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
-					<Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
-					<Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Channel" />
-				</RelationshipType>
-				<RelationshipType ID="IBM.MQ.QueueManager.Hosts.Listener" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
-					<Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
-					<Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Listener" />
-				</RelationshipType>
-				<RelationshipType ID="IBM.MQ.QueueManager.Hosts.Queue" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
-					<Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
-					<Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Queue" />
-				</RelationshipType>
-			</RelationshipTypes>
-		</EntityTypes>			
+  <Manifest>
+    <Identity>
+      <ID>IBM.MQ</ID>
+      <Version>3.2.1.6</Version>
+    </Identity>
+    <Name>IBM.MQ</Name>
+    <References>
+      <Reference Alias="SC">
+        <ID>Microsoft.SystemCenter.Library</ID>
+        <Version>7.0.8433.0</Version>
+        <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
+      </Reference>
+      <Reference Alias="Windows">
+        <ID>Microsoft.Windows.Library</ID>
+        <Version>7.5.8501.0</Version>
+        <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
+      </Reference>
+      <Reference Alias="System">
+        <ID>System.Library</ID>
+        <Version>7.5.8501.0</Version>
+        <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
+      </Reference>
+      <Reference Alias="Health">
+        <ID>System.Health.Library</ID>
+        <Version>7.0.8433.0</Version>
+        <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
+      </Reference>
+      <Reference Alias="Perf">
+        <ID>System.Performance.Library</ID>
+        <Version>7.0.8433.0</Version>
+        <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
+      </Reference>
+      <Reference Alias="MSDL">
+        <ID>Microsoft.SystemCenter.DataWarehouse.Library</ID>
+        <Version>7.1.10226.0</Version>
+        <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
+      </Reference>
+    </References>
+  </Manifest>
+  <TypeDefinitions>
+    <EntityTypes>
+      <ClassTypes>
+        <ClassType ID="IBM.MQ.Channel" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
+          <Property ID="ChannelName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+          <Property ID="ChannelType" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+          <Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+        </ClassType>
+        <ClassType ID="IBM.MQ.Listener" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
+          <Property ID="ListenerName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+          <Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+        </ClassType>
+        <ClassType ID="IBM.MQ.Queue" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
+          <Property ID="DESCR" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+          <Property ID="MAXDEPTH" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+          <Property ID="MAXMSGL" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+          <Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+          <Property ID="QueueName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+          <Property ID="TYPE" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+        </ClassType>
+        <ClassType ID="IBM.MQ.QueueManager" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
+          <Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+        </ClassType>
+        <ClassType ID="IBM.MQ.Server" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.LocalApplication" Hosted="true" Singleton="false" Extension="false">
+          <Property ID="Version" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+          <Property ID="InstallPath" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+        </ClassType>
+      </ClassTypes>
+      <RelationshipTypes>
+        <RelationshipType ID="IBM.MQ.Server.Hosts.QueueManager" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
+          <Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Server" />
+          <Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
+        </RelationshipType>
+        <RelationshipType ID="IBM.MQ.QueueManager.Hosts.Channel" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
+          <Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
+          <Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Channel" />
+        </RelationshipType>
+        <RelationshipType ID="IBM.MQ.QueueManager.Hosts.Listener" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
+          <Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
+          <Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Listener" />
+        </RelationshipType>
+        <RelationshipType ID="IBM.MQ.QueueManager.Hosts.Queue" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
+          <Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
+          <Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Queue" />
+        </RelationshipType>
+      </RelationshipTypes>
+    </EntityTypes>
     <ModuleTypes>
       <DataSourceModuleType ID="IBM.MQ.QueuePerformance.Filtered.DS" Accessibility="Public" Batching="false">
         <Configuration>
-		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />		  
+          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -107,31 +106,31 @@
               </DataSource>
               <ConditionDetection ID="Filter" TypeID="System!System.ExpressionFilter">
                 <Expression>
-					<And>
-					  <Expression>
-						<SimpleExpression>
-						  <ValueExpression>
-							<XPathQuery Type="String">Property[@Name='QueueName']</XPathQuery>
-						  </ValueExpression>
-						  <Operator>Equal</Operator>
-						  <ValueExpression>
-							<Value Type="String">$Config/QueueName$</Value>
-						  </ValueExpression>
-						</SimpleExpression>
-					  </Expression>
-					  <Expression>
-						<SimpleExpression>
-						  <ValueExpression>
-							<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-						  </ValueExpression>
-						  <Operator>Equal</Operator>
-						  <ValueExpression>
-							<Value Type="String">$Config/QueueManagerName$</Value>
-						  </ValueExpression>
-						</SimpleExpression>
-					  </Expression>
-					</And>
-		        </Expression>
+                  <And>
+                    <Expression>
+                      <SimpleExpression>
+                        <ValueExpression>
+                          <XPathQuery Type="String">Property[@Name='QueueName']</XPathQuery>
+                        </ValueExpression>
+                        <Operator>Equal</Operator>
+                        <ValueExpression>
+                          <Value Type="String">$Config/QueueName$</Value>
+                        </ValueExpression>
+                      </SimpleExpression>
+                    </Expression>
+                    <Expression>
+                      <SimpleExpression>
+                        <ValueExpression>
+                          <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+                        </ValueExpression>
+                        <Operator>Equal</Operator>
+                        <ValueExpression>
+                          <Value Type="String">$Config/QueueManagerName$</Value>
+                        </ValueExpression>
+                      </SimpleExpression>
+                    </Expression>
+                  </And>
+                </Expression>
               </ConditionDetection>
             </MemberModules>
             <Composition>
@@ -142,15 +141,15 @@
           </Composite>
         </ModuleImplementation>
         <OutputType>System!System.PropertyBagData</OutputType>
-      </DataSourceModuleType>	
+      </DataSourceModuleType>
       <DataSourceModuleType ID="IBM.MQ.QueuePerformance.DS" Accessibility="Internal" Batching="false">
         <Configuration>
-		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />	
+          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -159,7 +158,7 @@
                 <Scheduler>
                   <SimpleReccuringSchedule>
                     <Interval Unit="Seconds">$Config/IntervalSeconds$</Interval>
-					<SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
+                    <SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
                   </SimpleReccuringSchedule>
                   <ExcludeDates />
                 </Scheduler>
@@ -243,9 +242,9 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $QD = $QD.Substring(0, $QD.IndexOf(')'))
           $QD = $QD -Replace "[()]",""
           $QD = $QD.Trim()
-		  [int]$QueueDepth = $QD
+                                [int]$QueueDepth = $QD
           #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) QueueDepth:($QueueDepth)"
-		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nQueueDepth:($QueueDepth).")
+                                #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nQueueDepth:($QueueDepth).")
         }
 
         #Get IPPROCS
@@ -258,9 +257,9 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $QIPPROCS = $QIPPROCS.Substring(0, $QIPPROCS.IndexOf(')'))
           $QIPPROCS = $QIPPROCS -Replace "[()]",""
           $QIPPROCS = $QIPPROCS.Trim()
-		  [int]$IPPROCS = $QIPPROCS
+                                [int]$IPPROCS = $QIPPROCS
           #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) IPPROCS:($IPPROCS)"
-		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nIPPROCS:($IPPROCS).")
+                                #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nIPPROCS:($IPPROCS).")
         }
 
         #Get OPPROCS
@@ -273,9 +272,9 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $QOPPROCS = $QOPPROCS.Substring(0, $QOPPROCS.IndexOf(')'))
           $QOPPROCS = $QOPPROCS -Replace "[()]",""
           $QOPPROCS = $QOPPROCS.Trim()
-		  [int]$OPPROCS = $QOPPROCS
+                                [int]$OPPROCS = $QOPPROCS
           #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) OPPROCS:($OPPROCS)"
-		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nOPPROCS:($OPPROCS).")
+                                #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nOPPROCS:($OPPROCS).")
         }
 
         #Get Queue MAXDEPTH
@@ -288,9 +287,9 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $QMAXDEPTH = $QMAXDEPTH.Substring(0, $QMAXDEPTH.IndexOf(')'))
           $QMAXDEPTH = $QMAXDEPTH -Replace "[()]",""
           $QMAXDEPTH = $QMAXDEPTH.Trim()
-		  [int]$MAXDEPTH = $QMAXDEPTH
+                                [int]$MAXDEPTH = $QMAXDEPTH
           #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) MAXDEPTH:($MAXDEPTH)"
-		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nMAXDEPTH:($MAXDEPTH).")
+                                #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nMAXDEPTH:($MAXDEPTH).")
         }
       }
 
@@ -302,14 +301,14 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
       $bag = $momapi.CreatePropertyBag()
       #Create PropertyBags
       $bag.AddValue('QueueManagerName',$QueueManagerName)
-	  $bag.AddValue('QueueName',$QueueName)
-	  $bag.AddValue('QueueDepth',$QueueDepth)
-	  $bag.AddValue('MAXDEPTH',$MAXDEPTH)
-	  $bag.AddValue('QueuePercentUsed',$QueuePercentUsed)
-	  $bag.AddValue('IPPROCS',$IPPROCS)
-	  $bag.AddValue('OPPROCS',$OPPROCS)
-	  #Return each property bag as we create and populate it.
-	  $bag
+                 $bag.AddValue('QueueName',$QueueName)
+                 $bag.AddValue('QueueDepth',$QueueDepth)
+                 $bag.AddValue('MAXDEPTH',$MAXDEPTH)
+                 $bag.AddValue('QueuePercentUsed',$QueuePercentUsed)
+                 $bag.AddValue('IPPROCS',$IPPROCS)
+                 $bag.AddValue('OPPROCS',$OPPROCS)
+                 #Return each property bag as we create and populate it.
+                 $bag
     }
   }
 }
@@ -326,8 +325,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #=================================================================================
 # End of script
                 </ScriptBody>
-                <Parameters>
-                </Parameters>				
+                <Parameters></Parameters>
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
             </MemberModules>
@@ -342,14 +340,14 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
       </DataSourceModuleType>
       <DataSourceModuleType ID="IBM.MQ.ListenerPerformance.Filtered.DS" Accessibility="Public" Batching="false">
         <Configuration>
-		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="ListenerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />		  
+          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="ListenerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -360,31 +358,31 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
               </DataSource>
               <ConditionDetection ID="Filter" TypeID="System!System.ExpressionFilter">
                 <Expression>
-					<And>
-					  <Expression>
-						<SimpleExpression>
-						  <ValueExpression>
-							<XPathQuery Type="String">Property[@Name='ListenerName']</XPathQuery>
-						  </ValueExpression>
-						  <Operator>Equal</Operator>
-						  <ValueExpression>
-							<Value Type="String">$Config/ListenerName$</Value>
-						  </ValueExpression>
-						</SimpleExpression>
-					  </Expression>
-					  <Expression>
-						<SimpleExpression>
-						  <ValueExpression>
-							<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-						  </ValueExpression>
-						  <Operator>Equal</Operator>
-						  <ValueExpression>
-							<Value Type="String">$Config/QueueManagerName$</Value>
-						  </ValueExpression>
-						</SimpleExpression>
-					  </Expression>
-					</And>
-		        </Expression>
+                  <And>
+                    <Expression>
+                      <SimpleExpression>
+                        <ValueExpression>
+                          <XPathQuery Type="String">Property[@Name='ListenerName']</XPathQuery>
+                        </ValueExpression>
+                        <Operator>Equal</Operator>
+                        <ValueExpression>
+                          <Value Type="String">$Config/ListenerName$</Value>
+                        </ValueExpression>
+                      </SimpleExpression>
+                    </Expression>
+                    <Expression>
+                      <SimpleExpression>
+                        <ValueExpression>
+                          <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+                        </ValueExpression>
+                        <Operator>Equal</Operator>
+                        <ValueExpression>
+                          <Value Type="String">$Config/QueueManagerName$</Value>
+                        </ValueExpression>
+                      </SimpleExpression>
+                    </Expression>
+                  </And>
+                </Expression>
               </ConditionDetection>
             </MemberModules>
             <Composition>
@@ -395,15 +393,15 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
           </Composite>
         </ModuleImplementation>
         <OutputType>System!System.PropertyBagData</OutputType>
-      </DataSourceModuleType>	
+      </DataSourceModuleType>
       <DataSourceModuleType ID="IBM.MQ.ListenerPerformance.DS" Accessibility="Internal" Batching="false">
         <Configuration>
-		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />	
+          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -412,7 +410,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
                 <Scheduler>
                   <SimpleReccuringSchedule>
                     <Interval Unit="Seconds">$Config/IntervalSeconds$</Interval>
-					<SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
+                    <SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
                   </SimpleReccuringSchedule>
                   <ExcludeDates />
                 </Scheduler>
@@ -502,11 +500,11 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $bag = $momapi.CreatePropertyBag()
 
           #Create PropertyBags
-	      $bag.AddValue('QueueManagerName',$QueueManagerName)
-	      $bag.AddValue('ListenerName',$ListenerName)
-	      $bag.AddValue('LSessionsValue',$LSessionsValue)
-	      #Return each property bag as we create and populate it.
-	      $bag
+                     $bag.AddValue('QueueManagerName',$QueueManagerName)
+                     $bag.AddValue('ListenerName',$ListenerName)
+                     $bag.AddValue('LSessionsValue',$LSessionsValue)
+                     #Return each property bag as we create and populate it.
+                     $bag
         }
       }
     }
@@ -525,10 +523,9 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #=================================================================================
 # End of script
                 </ScriptBody>
-                <Parameters>
-                </Parameters>				
+                <Parameters></Parameters>
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
-              </ProbeAction>
+             </ProbeAction>
             </MemberModules>
             <Composition>
               <Node ID="PA">
@@ -538,15 +535,15 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
           </Composite>
         </ModuleImplementation>
         <OutputType>System!System.PropertyBagData</OutputType>
-      </DataSourceModuleType>	  
+      </DataSourceModuleType>
       <DataSourceModuleType ID="IBM.MQ.ChannelStatus.Monitor.DS" Accessibility="Internal" Batching="false">
         <Configuration>
-		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />	
+          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -555,7 +552,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
                 <Scheduler>
                   <SimpleReccuringSchedule>
                     <Interval Unit="Seconds">$Config/IntervalSeconds$</Interval>
-					<SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
+                    <SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
                   </SimpleReccuringSchedule>
                   <ExcludeDates />
                 </Scheduler>
@@ -639,16 +636,16 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $CStatus = $CStatus -Replace "[()]",""
           $CStatus = $CStatus.Trim()
           #Write-Host "CStatus: ($CStatus)"
-		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName). `nChannelName:($ChannelName). `nChannelStatus:($CStatus).")
+                                #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName). `nChannelName:($ChannelName). `nChannelStatus:($CStatus).")
 
           # Load PropertyBag function 
           $bag = $momapi.CreatePropertyBag()
           #Create PropertyBags
-	      $bag.AddValue('QueueManagerName',$QueueManagerName)
-	      $bag.AddValue('ChannelName',$ChannelName)
-	      $bag.AddValue('CStatus',$CStatus)
-	      #Return each property bag as we create and populate it.
-	      $bag
+                     $bag.AddValue('QueueManagerName',$QueueManagerName)
+                     $bag.AddValue('ChannelName',$ChannelName)
+                     $bag.AddValue('CStatus',$CStatus)
+                     #Return each property bag as we create and populate it.
+                     $bag
 
           #Break out of this loop in the case there might be 
           #multiple channels returned for a single channel name
@@ -672,8 +669,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #=================================================================================
 # End of script
                 </ScriptBody>
-                <Parameters>
-                </Parameters>				
+                <Parameters></Parameters>
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
             </MemberModules>
@@ -688,12 +684,12 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
       </DataSourceModuleType>
       <DataSourceModuleType ID="IBM.MQ.ListenerStatus.Monitor.DS" Accessibility="Internal" Batching="false">
         <Configuration>
-		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />	
+          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -702,7 +698,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
                 <Scheduler>
                   <SimpleReccuringSchedule>
                     <Interval Unit="Seconds">$Config/IntervalSeconds$</Interval>
-					<SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
+                    <SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
                   </SimpleReccuringSchedule>
                   <ExcludeDates />
                 </Scheduler>
@@ -784,16 +780,16 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $LStatus = $LStatus -Replace "[()]",""
           $LStatus = $LStatus.Trim()
           #Write-Host "LStatus: ($LStatus)"
-		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName). `nListenerName:($ListenerName). `nListenerStatus:($LStatus).")
+                                #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName). `nListenerName:($ListenerName). `nListenerStatus:($LStatus).")
 
           # Load PropertyBag function 
           $bag = $momapi.CreatePropertyBag()
           #Create PropertyBags
-	      $bag.AddValue('QueueManagerName',$QueueManagerName)
-	      $bag.AddValue('ListenerName',$ListenerName)
-	      $bag.AddValue('LStatus',$LStatus)
-	      #Return each property bag as we create and populate it.
-	      $bag
+                     $bag.AddValue('QueueManagerName',$QueueManagerName)
+                     $bag.AddValue('ListenerName',$ListenerName)
+                     $bag.AddValue('LStatus',$LStatus)
+                     #Return each property bag as we create and populate it.
+                     $bag
         }
       }
     }
@@ -812,8 +808,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #=================================================================================
 # End of script
                 </ScriptBody>
-                <Parameters>
-                </Parameters>				
+                <Parameters></Parameters>
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
             </MemberModules>
@@ -828,21 +823,21 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
       </DataSourceModuleType>
       <DataSourceModuleType ID="IBM.MQ.QueueManagerStatus.Monitor.DS" Accessibility="Internal" Batching="false">
         <Configuration>
-		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />	
+          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
-            <MemberModules>
+           <MemberModules>
               <DataSource ID="Scheduler" TypeID="System!System.Scheduler">
                 <Scheduler>
                   <SimpleReccuringSchedule>
                     <Interval Unit="Seconds">$Config/IntervalSeconds$</Interval>
-					<SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
+                   <SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
                   </SimpleReccuringSchedule>
                   <ExcludeDates />
                 </Scheduler>
@@ -907,7 +902,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
   $bag = $momapi.CreatePropertyBag()
   #Create PropertyBags
   $bag.AddValue('QueueManagerName',$QueueManagerName)
-  $bag.AddValue('QMGRStatus',$QMGRStatus)
+ $bag.AddValue('QMGRStatus',$QMGRStatus)
   #Return each property bag as we create and populate it.
   $bag
 }
@@ -924,8 +919,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #=================================================================================
 # End of script
                 </ScriptBody>
-                <Parameters>
-                </Parameters>				
+                <Parameters></Parameters>
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
             </MemberModules>
@@ -944,42 +938,42 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
         <MonitorTypeStates>
           <MonitorTypeState ID="Error" NoDetection="false" />
           <MonitorTypeState ID="Warning" NoDetection="false" />
-		  <MonitorTypeState ID="Success" NoDetection="false" />
+          <MonitorTypeState ID="Success" NoDetection="false" />
         </MonitorTypeStates>
         <Configuration>
           <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
           <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:integer" name="WarningThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:integer" name="CriticalThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />		  
+          <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:integer" name="WarningThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:integer" name="CriticalThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="WarningThreshold" Selector="$Config/WarningThreshold$" ParameterType="int" />
-		  <OverrideableParameter ID="CriticalThreshold" Selector="$Config/CriticalThreshold$" ParameterType="int" />		  
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="WarningThreshold" Selector="$Config/WarningThreshold$" ParameterType="int" />
+          <OverrideableParameter ID="CriticalThreshold" Selector="$Config/CriticalThreshold$" ParameterType="int" />
         </OverrideableParameters>
         <MonitorImplementation>
           <MemberModules>
             <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-			  <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
-			  <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+              <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               <QueueName>$Config/QueueName$</QueueName>
-		      <QueueManagerName>$Config/QueueManagerName$</QueueManagerName>			  
+              <QueueManagerName>$Config/QueueManagerName$</QueueManagerName>
             </DataSource>
             <ConditionDetection ID="HealthyCondition" TypeID="System!System.ExpressionFilter">
-			  <Expression>
-				<SimpleExpression>
-				  <ValueExpression>
-					<XPathQuery Type="Integer">Property[@Name='QueueDepth']</XPathQuery>
-				  </ValueExpression>
-				  <Operator>Less</Operator>
-				  <ValueExpression>
-					<Value Type="Integer">$Config/WarningThreshold$</Value>
-				  </ValueExpression>
-				</SimpleExpression>
-			  </Expression>
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <XPathQuery Type="Integer">Property[@Name='QueueDepth']</XPathQuery>
+                  </ValueExpression>
+                  <Operator>Less</Operator>
+                  <ValueExpression>
+                    <Value Type="Integer">$Config/WarningThreshold$</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
             </ConditionDetection>
             <ConditionDetection ID="WarningCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
@@ -1006,21 +1000,21 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
                       </ValueExpression>
                     </SimpleExpression>
                   </Expression>
-				</And>
-		      </Expression>				  
-            </ConditionDetection>			
+                </And>
+              </Expression>
+            </ConditionDetection>
             <ConditionDetection ID="CriticalCondition" TypeID="System!System.ExpressionFilter">
-			  <Expression>
-				<SimpleExpression>
-				  <ValueExpression>
-					<XPathQuery Type="Integer">Property[@Name='QueueDepth']</XPathQuery>
-				  </ValueExpression>
-				  <Operator>GreaterEqual</Operator>
-				  <ValueExpression>
-					<Value Type="Integer">$Config/CriticalThreshold$</Value>
-				  </ValueExpression>
-				</SimpleExpression>
-			  </Expression>
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <XPathQuery Type="Integer">Property[@Name='QueueDepth']</XPathQuery>
+                  </ValueExpression>
+                  <Operator>GreaterEqual</Operator>
+                  <ValueExpression>
+                    <Value Type="Integer">$Config/CriticalThreshold$</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
             </ConditionDetection>
           </MemberModules>
           <RegularDetections>
@@ -1046,42 +1040,42 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
         <MonitorTypeStates>
           <MonitorTypeState ID="Error" NoDetection="false" />
           <MonitorTypeState ID="Warning" NoDetection="false" />
-		  <MonitorTypeState ID="Success" NoDetection="false" />
+          <MonitorTypeState ID="Success" NoDetection="false" />
         </MonitorTypeStates>
         <Configuration>
           <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
           <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:integer" name="WarningThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:integer" name="CriticalThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />		  
+          <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:integer" name="WarningThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:integer" name="CriticalThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="WarningThreshold" Selector="$Config/WarningThreshold$" ParameterType="int" />
-		  <OverrideableParameter ID="CriticalThreshold" Selector="$Config/CriticalThreshold$" ParameterType="int" />		  
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="WarningThreshold" Selector="$Config/WarningThreshold$" ParameterType="int" />
+          <OverrideableParameter ID="CriticalThreshold" Selector="$Config/CriticalThreshold$" ParameterType="int" />
         </OverrideableParameters>
         <MonitorImplementation>
           <MemberModules>
             <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-			  <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
-			  <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+              <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               <QueueName>$Config/QueueName$</QueueName>
-		      <QueueManagerName>$Config/QueueManagerName$</QueueManagerName>			  
+              <QueueManagerName>$Config/QueueManagerName$</QueueManagerName>
             </DataSource>
             <ConditionDetection ID="HealthyCondition" TypeID="System!System.ExpressionFilter">
-			  <Expression>
-				<SimpleExpression>
-				  <ValueExpression>
-					<XPathQuery Type="Integer">Property[@Name='QueuePercentUsed']</XPathQuery>
-				  </ValueExpression>
-				  <Operator>Less</Operator>
-				  <ValueExpression>
-					<Value Type="Integer">$Config/WarningThreshold$</Value>
-				  </ValueExpression>
-				</SimpleExpression>
-			  </Expression>
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <XPathQuery Type="Integer">Property[@Name='QueuePercentUsed']</XPathQuery>
+                  </ValueExpression>
+                  <Operator>Less</Operator>
+                  <ValueExpression>
+                    <Value Type="Integer">$Config/WarningThreshold$</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
             </ConditionDetection>
             <ConditionDetection ID="WarningCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
@@ -1108,21 +1102,21 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
                       </ValueExpression>
                     </SimpleExpression>
                   </Expression>
-				</And>
-		      </Expression>				  
-            </ConditionDetection>			
+                </And>
+              </Expression>
+            </ConditionDetection>
             <ConditionDetection ID="CriticalCondition" TypeID="System!System.ExpressionFilter">
-			  <Expression>
-				<SimpleExpression>
-				  <ValueExpression>
-					<XPathQuery Type="Integer">Property[@Name='QueuePercentUsed']</XPathQuery>
-				  </ValueExpression>
-				  <Operator>GreaterEqual</Operator>
-				  <ValueExpression>
-					<Value Type="Integer">$Config/CriticalThreshold$</Value>
-				  </ValueExpression>
-				</SimpleExpression>
-			  </Expression>
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <XPathQuery Type="Integer">Property[@Name='QueuePercentUsed']</XPathQuery>
+                  </ValueExpression>
+                  <Operator>GreaterEqual</Operator>
+                  <ValueExpression>
+                    <Value Type="Integer">$Config/CriticalThreshold$</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
             </ConditionDetection>
           </MemberModules>
           <RegularDetections>
@@ -1143,55 +1137,55 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
             </RegularDetection>
           </RegularDetections>
         </MonitorImplementation>
-      </UnitMonitorType>	  
+      </UnitMonitorType>
       <UnitMonitorType ID="IBM.MQ.QueueIPPROCS.Monitor.MonitorType" Accessibility="Internal">
         <MonitorTypeStates>
           <MonitorTypeState ID="Error" NoDetection="false" />
-		  <MonitorTypeState ID="Success" NoDetection="false" />
+          <MonitorTypeState ID="Success" NoDetection="false" />
         </MonitorTypeStates>
         <Configuration>
           <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
           <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <MonitorImplementation>
           <MemberModules>
             <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-			  <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
-			  <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+              <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               <QueueName>$Config/QueueName$</QueueName>
-		      <QueueManagerName>$Config/QueueManagerName$</QueueManagerName>
+              <QueueManagerName>$Config/QueueManagerName$</QueueManagerName>
             </DataSource>
             <ConditionDetection ID="HealthyCondition" TypeID="System!System.ExpressionFilter">
-			  <Expression>
-				<SimpleExpression>
-				  <ValueExpression>
-					<XPathQuery Type="Integer">Property[@Name='IPPROCS']</XPathQuery>
-				  </ValueExpression>
-				  <Operator>Greater</Operator>
-				  <ValueExpression>
-					<Value Type="Integer">0</Value>
-				  </ValueExpression>
-				</SimpleExpression>
-			  </Expression>
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <XPathQuery Type="Integer">Property[@Name='IPPROCS']</XPathQuery>
+                 </ValueExpression>
+                  <Operator>Greater</Operator>
+                  <ValueExpression>
+                    <Value Type="Integer">0</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
             </ConditionDetection>
             <ConditionDetection ID="UnhealthyCondition" TypeID="System!System.ExpressionFilter">
-			  <Expression>
-				<SimpleExpression>
-				  <ValueExpression>
-					<XPathQuery Type="Integer">Property[@Name='IPPROCS']</XPathQuery>
-				  </ValueExpression>
-				  <Operator>Equal</Operator>
-				  <ValueExpression>
-					<Value Type="Integer">0</Value>
-				  </ValueExpression>
-				</SimpleExpression>
-			  </Expression>
+              <Expression>
+                <SimpleExpression>
+                  <ValueExpression>
+                    <XPathQuery Type="Integer">Property[@Name='IPPROCS']</XPathQuery>
+                  </ValueExpression>
+                  <Operator>Equal</Operator>
+                  <ValueExpression>
+                    <Value Type="Integer">0</Value>
+                  </ValueExpression>
+                </SimpleExpression>
+              </Expression>
             </ConditionDetection>
           </MemberModules>
           <RegularDetections>
@@ -1207,153 +1201,153 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
             </RegularDetection>
           </RegularDetections>
         </MonitorImplementation>
-      </UnitMonitorType>	  
+      </UnitMonitorType>
       <UnitMonitorType ID="IBM.MQ.ChannelStatus.Monitor.MonitorType" Accessibility="Internal">
         <MonitorTypeStates>
           <MonitorTypeState ID="Error" NoDetection="false" />
-		  <MonitorTypeState ID="Success" NoDetection="false" />
+          <MonitorTypeState ID="Success" NoDetection="false" />
         </MonitorTypeStates>
         <Configuration>
           <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="ChannelName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="ChannelName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
           <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+         <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <MonitorImplementation>
           <MemberModules>
             <DataSource ID="DS" TypeID="IBM.MQ.ChannelStatus.Monitor.DS">
-			  <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
-			  <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+              <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
             </DataSource>
             <ConditionDetection ID="HealthyCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
-				  <And>
-					  <Expression>			  
-						<Or>
-							<Expression>
-								<SimpleExpression>
-									<ValueExpression>
-										<XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
-									</ValueExpression>
-									<Operator>Equal</Operator>
-									<ValueExpression>
-										<Value Type="String">RUNNING</Value>
-									</ValueExpression>
-								</SimpleExpression>
-							</Expression>
-							<Expression>
-								<SimpleExpression>
-									<ValueExpression>
-										<XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
-									</ValueExpression>
-									<Operator>Equal</Operator>
-									<ValueExpression>
-										<Value Type="String">INACTIVE</Value>
-									</ValueExpression>
-								</SimpleExpression>
-							</Expression>
-							<Expression>
-								<SimpleExpression>
-									<ValueExpression>
-										<XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
-									</ValueExpression>
-									<Operator>Equal</Operator>
-									<ValueExpression>
-										<Value Type="String">Not Available</Value>
-									</ValueExpression>
-								</SimpleExpression>
-							</Expression>
-						</Or>
-					  </Expression>
-					  <Expression>
-						<SimpleExpression>
-						  <ValueExpression>
-							<XPathQuery Type="String">Property[@Name='ChannelName']</XPathQuery>
-						  </ValueExpression>
-						  <Operator>Equal</Operator>
-						  <ValueExpression>
-							<Value Type="String">$Config/ChannelName$</Value>
-						  </ValueExpression>
-						</SimpleExpression>
-					  </Expression>
-					  <Expression>
-						<SimpleExpression>
-						  <ValueExpression>
-							<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-						  </ValueExpression>
-						  <Operator>Equal</Operator>
-						  <ValueExpression>
-							<Value Type="String">$Config/QueueManagerName$</Value>
-						  </ValueExpression>
-						</SimpleExpression>
-					  </Expression>
-				  </And>
-			  </Expression>			  
+                <And>
+                  <Expression>
+                    <Or>
+                      <Expression>
+                        <SimpleExpression>
+                          <ValueExpression>
+                            <XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
+                          </ValueExpression>
+                          <Operator>Equal</Operator>
+                          <ValueExpression>
+                            <Value Type="String">RUNNING</Value>
+                          </ValueExpression>
+                        </SimpleExpression>
+                     </Expression>
+                      <Expression>
+                        <SimpleExpression>
+                          <ValueExpression>
+                            <XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
+                          </ValueExpression>
+                          <Operator>Equal</Operator>
+                          <ValueExpression>
+                            <Value Type="String">INACTIVE</Value>
+                          </ValueExpression>
+                        </SimpleExpression>
+                      </Expression>
+                      <Expression>
+                        <SimpleExpression>
+                          <ValueExpression>
+                            <XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
+                          </ValueExpression>
+                          <Operator>Equal</Operator>
+                          <ValueExpression>
+                            <Value Type="String">Not Available</Value>
+                          </ValueExpression>
+                        </SimpleExpression>
+                      </Expression>
+                    </Or>
+                  </Expression>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='ChannelName']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>Equal</Operator>
+                      <ValueExpression>
+                        <Value Type="String">$Config/ChannelName$</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>Equal</Operator>
+                      <ValueExpression>
+                        <Value Type="String">$Config/QueueManagerName$</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                </And>
+              </Expression>
             </ConditionDetection>
             <ConditionDetection ID="UnhealthyCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
-				<And>
-					<Expression>
-						<SimpleExpression>
-							<ValueExpression>
-								<XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
-							</ValueExpression>
-							<Operator>NotEqual</Operator>
-							<ValueExpression>
-								<Value Type="String">RUNNING</Value>
-							</ValueExpression>
-						</SimpleExpression>
-					</Expression>
-					<Expression>
-						<SimpleExpression>
-							<ValueExpression>
-								<XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
-							</ValueExpression>
-							<Operator>NotEqual</Operator>
-							<ValueExpression>
-								<Value Type="String">INACTIVE</Value>
-							</ValueExpression>
-						</SimpleExpression>
-					</Expression>
-					<Expression>
-						<SimpleExpression>
-							<ValueExpression>
-								<XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
-							</ValueExpression>
-							<Operator>NotEqual</Operator>
-							<ValueExpression>
-								<Value Type="String">Not Available</Value>
-							</ValueExpression>
-						</SimpleExpression>
-					</Expression>
-				  <Expression>
-					<SimpleExpression>
-					  <ValueExpression>
-						<XPathQuery Type="String">Property[@Name='ChannelName']</XPathQuery>
-					  </ValueExpression>
-					  <Operator>Equal</Operator>
-					  <ValueExpression>
-						<Value Type="String">$Config/ChannelName$</Value>
-					  </ValueExpression>
-					</SimpleExpression>
-				  </Expression>
-				  <Expression>
-					<SimpleExpression>
-					  <ValueExpression>
-						<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-					  </ValueExpression>
-					  <Operator>Equal</Operator>
-					  <ValueExpression>
-						<Value Type="String">$Config/QueueManagerName$</Value>
-					  </ValueExpression>
-					</SimpleExpression>
-				  </Expression>					
-				</And>
-		      </Expression>				  
+                <And>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>NotEqual</Operator>
+                      <ValueExpression>
+                        <Value Type="String">RUNNING</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>NotEqual</Operator>
+                      <ValueExpression>
+                        <Value Type="String">INACTIVE</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>NotEqual</Operator>
+                      <ValueExpression>
+                        <Value Type="String">Not Available</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='ChannelName']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>Equal</Operator>
+                      <ValueExpression>
+                        <Value Type="String">$Config/ChannelName$</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>Equal</Operator>
+                      <ValueExpression>
+                        <Value Type="String">$Config/QueueManagerName$</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                </And>
+              </Expression>
             </ConditionDetection>
           </MemberModules>
           <RegularDetections>
@@ -1373,101 +1367,101 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
       <UnitMonitorType ID="IBM.MQ.ListenerStatus.Monitor.MonitorType" Accessibility="Internal">
         <MonitorTypeStates>
           <MonitorTypeState ID="Error" NoDetection="false" />
-		  <MonitorTypeState ID="Success" NoDetection="false" />
+          <MonitorTypeState ID="Success" NoDetection="false" />
         </MonitorTypeStates>
         <Configuration>
           <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="ListenerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="ListenerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
           <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <MonitorImplementation>
           <MemberModules>
             <DataSource ID="DS" TypeID="IBM.MQ.ListenerStatus.Monitor.DS">
-			  <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
-			  <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+              <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
             </DataSource>
             <ConditionDetection ID="HealthyCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
-				<And>
-				  <Expression>
-					<SimpleExpression>
-						<ValueExpression>
-							<XPathQuery Type="String">Property[@Name='LStatus']</XPathQuery>
-						</ValueExpression>
-						<Operator>Equal</Operator>
-						<ValueExpression>
-							<Value Type="String">RUNNING</Value>
-						</ValueExpression>
-					</SimpleExpression>
-				  </Expression>
-				  <Expression>
-					<SimpleExpression>
-					  <ValueExpression>
-						<XPathQuery Type="String">Property[@Name='ListenerName']</XPathQuery>
-					  </ValueExpression>
-					  <Operator>Equal</Operator>
-					  <ValueExpression>
-						<Value Type="String">$Config/ListenerName$</Value>
-					  </ValueExpression>
-					</SimpleExpression>
-				  </Expression>
-				  <Expression>
-					<SimpleExpression>
-					  <ValueExpression>
-						<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-					  </ValueExpression>
-					  <Operator>Equal</Operator>
-					  <ValueExpression>
-						<Value Type="String">$Config/QueueManagerName$</Value>
-					  </ValueExpression>
-					</SimpleExpression>
-				  </Expression>
-				</And>
-			  </Expression>			  
+                <And>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='LStatus']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>Equal</Operator>
+                      <ValueExpression>
+                        <Value Type="String">RUNNING</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                  <Expression>
+                    <SimpleExpression>
+                     <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='ListenerName']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>Equal</Operator>
+                      <ValueExpression>
+                        <Value Type="String">$Config/ListenerName$</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>Equal</Operator>
+                      <ValueExpression>
+                        <Value Type="String">$Config/QueueManagerName$</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                </And>
+              </Expression>
             </ConditionDetection>
             <ConditionDetection ID="UnhealthyCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
-				<And>
-				  <Expression>
-					<SimpleExpression>
-						<ValueExpression>
-							<XPathQuery Type="String">Property[@Name='LStatus']</XPathQuery>
-						</ValueExpression>
-						<Operator>NotEqual</Operator>
-						<ValueExpression>
-							<Value Type="String">RUNNING</Value>
-						</ValueExpression>
-					</SimpleExpression>
-				  </Expression>
-				  <Expression>
-					<SimpleExpression>
-					  <ValueExpression>
-						<XPathQuery Type="String">Property[@Name='ListenerName']</XPathQuery>
-					  </ValueExpression>
-					  <Operator>Equal</Operator>
-					  <ValueExpression>
-						<Value Type="String">$Config/ListenerName$</Value>
-					  </ValueExpression>
-					</SimpleExpression>
-				  </Expression>
-				  <Expression>
-					<SimpleExpression>
-					  <ValueExpression>
-						<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-					  </ValueExpression>
-					  <Operator>Equal</Operator>
-					  <ValueExpression>
-						<Value Type="String">$Config/QueueManagerName$</Value>
-					  </ValueExpression>
-					</SimpleExpression>
-				  </Expression>					
-				</And>
-		      </Expression>				  
+                <And>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='LStatus']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>NotEqual</Operator>
+                      <ValueExpression>
+                        <Value Type="String">RUNNING</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='ListenerName']</XPathQuery>
+                      </ValueExpression>
+                     <Operator>Equal</Operator>
+                      <ValueExpression>
+                        <Value Type="String">$Config/ListenerName$</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>Equal</Operator>
+                      <ValueExpression>
+                        <Value Type="String">$Config/QueueManagerName$</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                </And>
+              </Expression>
             </ConditionDetection>
           </MemberModules>
           <RegularDetections>
@@ -1485,84 +1479,84 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
         </MonitorImplementation>
       </UnitMonitorType>
       <UnitMonitorType ID="IBM.MQ.QueueManagerStatus.Monitor.MonitorType" Accessibility="Internal">
-        <MonitorTypeStates>
+       <MonitorTypeStates>
           <MonitorTypeState ID="Error" NoDetection="false" />
-		  <MonitorTypeState ID="Success" NoDetection="false" />
+          <MonitorTypeState ID="Success" NoDetection="false" />
         </MonitorTypeStates>
         <Configuration>
           <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
           <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <MonitorImplementation>
           <MemberModules>
             <DataSource ID="DS" TypeID="IBM.MQ.QueueManagerStatus.Monitor.DS">
-			  <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
-			  <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+              <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
             </DataSource>
             <ConditionDetection ID="HealthyCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
-				<And>
-				  <Expression>
-					<SimpleExpression>
-						<ValueExpression>
-							<XPathQuery Type="String">Property[@Name='QMGRStatus']</XPathQuery>
-						</ValueExpression>
-						<Operator>Equal</Operator>
-						<ValueExpression>
-							<Value Type="String">Running</Value>
-						</ValueExpression>
-					</SimpleExpression>
-				  </Expression>
-				  <Expression>
-					<SimpleExpression>
-					  <ValueExpression>
-						<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-					  </ValueExpression>
-					  <Operator>Equal</Operator>
-					  <ValueExpression>
-						<Value Type="String">$Config/QueueManagerName$</Value>
-					  </ValueExpression>
-					</SimpleExpression>
-				  </Expression>
-				</And>
-			  </Expression>			  
+                <And>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='QMGRStatus']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>Equal</Operator>
+                      <ValueExpression>
+                        <Value Type="String">Running</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>Equal</Operator>
+                      <ValueExpression>
+                        <Value Type="String">$Config/QueueManagerName$</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                </And>
+              </Expression>
             </ConditionDetection>
             <ConditionDetection ID="UnhealthyCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
-				<And>
-				  <Expression>
-					<SimpleExpression>
-						<ValueExpression>
-							<XPathQuery Type="String">Property[@Name='QMGRStatus']</XPathQuery>
-						</ValueExpression>
-						<Operator>NotEqual</Operator>
-						<ValueExpression>
-							<Value Type="String">Running</Value>
-						</ValueExpression>
-					</SimpleExpression>
-				  </Expression>
-				  <Expression>
-					<SimpleExpression>
-					  <ValueExpression>
-						<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-					  </ValueExpression>
-					  <Operator>Equal</Operator>
-					  <ValueExpression>
-						<Value Type="String">$Config/QueueManagerName$</Value>
-					  </ValueExpression>
-					</SimpleExpression>
-				  </Expression>					
-				</And>
-		      </Expression>				  
+                <And>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='QMGRStatus']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>NotEqual</Operator>
+                      <ValueExpression>
+                        <Value Type="String">Running</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                  <Expression>
+                    <SimpleExpression>
+                      <ValueExpression>
+                        <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+                      </ValueExpression>
+                      <Operator>Equal</Operator>
+                      <ValueExpression>
+                        <Value Type="String">$Config/QueueManagerName$</Value>
+                      </ValueExpression>
+                    </SimpleExpression>
+                  </Expression>
+                </And>
+              </Expression>
             </ConditionDetection>
           </MemberModules>
           <RegularDetections>
-            <RegularDetection MonitorTypeStateID="Error">
+           <RegularDetection MonitorTypeStateID="Error">
               <Node ID="UnhealthyCondition">
                 <Node ID="DS" />
               </Node>
@@ -1574,32 +1568,32 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
             </RegularDetection>
           </RegularDetections>
         </MonitorImplementation>
-      </UnitMonitorType>	  
-    </MonitorTypes>	
-	</TypeDefinitions>
-	<Monitoring>
-		<Discoveries>
-			<Discovery ID="IBM.MQ.Channel.Discovery" Enabled="true" Target="IBM.MQ.QueueManager" ConfirmDelivery="false" Remotable="true" Priority="Normal">
-				<Category>Discovery</Category>
-				<DiscoveryTypes>
-					<DiscoveryClass TypeID="IBM.MQ.Channel">
-						<Property TypeID="IBM.MQ.Channel" PropertyID="ChannelName" />
-						<Property TypeID="IBM.MQ.Channel" PropertyID="ChannelType" />						
-						<Property TypeID="IBM.MQ.Channel" PropertyID="QueueManagerName" />
-					</DiscoveryClass>
-				</DiscoveryTypes>
-				<DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
-				  <IntervalSeconds>86405</IntervalSeconds>
-				  <SyncTime />
-				  <ScriptName>IBM.MQ.Channel.Discovery.ps1</ScriptName>
-				  <ScriptBody>
+      </UnitMonitorType>
+    </MonitorTypes>
+  </TypeDefinitions>
+  <Monitoring>
+    <Discoveries>
+      <Discovery ID="IBM.MQ.Channel.Discovery" Enabled="true" Target="IBM.MQ.QueueManager" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="IBM.MQ.Channel">
+            <Property TypeID="IBM.MQ.Channel" PropertyID="ChannelName" />
+            <Property TypeID="IBM.MQ.Channel" PropertyID="ChannelType" />
+            <Property TypeID="IBM.MQ.Channel" PropertyID="QueueManagerName" />
+          </DiscoveryClass>
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
+          <IntervalSeconds>86405</IntervalSeconds>
+          <SyncTime />
+          <ScriptName>IBM.MQ.Channel.Discovery.ps1</ScriptName>
+          <ScriptBody>
 #=================================================================================
 #  Discover IBM MQ Channel Discovery
 #
 #  Author: Kevin Holman
 #  v1.2
 #=================================================================================
-param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName)
+param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName,$InstallPath)
 
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
@@ -1631,21 +1625,21 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #Log script event that we are starting task
 $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script is starting. `n Running as ($whoami).")
 #=================================================================================
-			
+                                            
 
 # Discovery Script section - Discovery scripts get this
 #=================================================================================
 # Load SCOM Discovery module
 $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
-#=================================================================================	
+#=================================================================================               
 
 
 # Begin MAIN script section
 #=================================================================================
 #Get the Channel from QueueManager
-$Ccmd = "cmd /c 'echo Display channel(*) | runmqsc $QueueManagerName'"
+$Ccmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display channel(*) | runmqsc $QueueManagerName'"
+$Cout = Invoke-Expression "$Ccmd"
 
-$Cout = Invoke-Expression $Ccmd
 FOREACH ($CLine in $Cout)
 {
   $Cmatch = $CLine | Select-String -Pattern 'CHANNEL\(' -CaseSensitive
@@ -1665,7 +1659,7 @@ FOREACH ($CLine in $Cout)
     $instance.AddProperty("$MPElement[Name='IBM.MQ.QueueManager']/QueueManagerName$",$QueueManagerName)
     $instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/ChannelName$",$ChannelName)
     $instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/ChannelType$",$ChannelType)
-    $instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/QueueManagerName$",$QueueManagerName)	
+    $instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/QueueManagerName$",$QueueManagerName)               
     $instance.AddProperty("$MPElement[Name='System!System.Entity']/DisplayName$", $ChannelName)
     $DiscoveryData.AddInstance($instance)
   }
@@ -1688,47 +1682,51 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 #=================================================================================
 # End of script
 </ScriptBody>
-				  <Parameters>
-					<Parameter>
-					  <Name>SourceID</Name>
-					  <Value>$MPElement$</Value>
-					</Parameter>
-					<Parameter>
-					  <Name>ManagedEntityID</Name>
-					  <Value>$Target/Id$</Value>
-					</Parameter>
-					<Parameter>
-					  <Name>ComputerName</Name>
-					  <Value>$Target/Host/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
-					</Parameter>
-					<Parameter>
-					  <Name>QueueManagerName</Name>
-					  <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
-					</Parameter>					
-				  </Parameters>
-				  <TimeoutSeconds>300</TimeoutSeconds>
-				</DataSource>				
-			</Discovery>
-			<Discovery ID="IBM.MQ.Listener.Discovery" Enabled="true" Target="IBM.MQ.QueueManager" ConfirmDelivery="false" Remotable="true" Priority="Normal">
-				<Category>Discovery</Category>
-				<DiscoveryTypes>
-					<DiscoveryClass TypeID="IBM.MQ.Listener">
-						<Property TypeID="IBM.MQ.Listener" PropertyID="ListenerName" />
-						<Property TypeID="IBM.MQ.Listener" PropertyID="QueueManagerName" />
-					</DiscoveryClass>
-				</DiscoveryTypes>
-				<DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
-				  <IntervalSeconds>86403</IntervalSeconds>
-				  <SyncTime />
-				  <ScriptName>IBM.MQ.Listener.Discovery.ps1</ScriptName>
-				  <ScriptBody>
+          <Parameters>
+            <Parameter>
+              <Name>SourceID</Name>
+              <Value>$MPElement$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>ManagedEntityID</Name>
+              <Value>$Target/Id$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>ComputerName</Name>
+              <Value>$Target/Host/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>QueueManagerName</Name>
+              <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>InstallPath</Name>
+              <Value>$Target/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
+            </Parameter>
+          </Parameters>
+          <TimeoutSeconds>300</TimeoutSeconds>
+        </DataSource>
+      </Discovery>
+      <Discovery ID="IBM.MQ.Listener.Discovery" Enabled="true" Target="IBM.MQ.QueueManager" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="IBM.MQ.Listener">
+            <Property TypeID="IBM.MQ.Listener" PropertyID="ListenerName" />
+            <Property TypeID="IBM.MQ.Listener" PropertyID="QueueManagerName" />
+          </DiscoveryClass>
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
+         <IntervalSeconds>86403</IntervalSeconds>
+          <SyncTime />
+          <ScriptName>IBM.MQ.Listener.Discovery.ps1</ScriptName>
+          <ScriptBody>
 #=================================================================================
 #  Discover IBM MQ Queue Listener Discovery
 #
 #  Author: Kevin Holman
 #  v1.1
 #=================================================================================
-param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName)
+param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName,$InstallPath)
 
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
@@ -1760,21 +1758,21 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #Log script event that we are starting task
 $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script is starting. `n Running as ($whoami).")
 #=================================================================================
-			
+                                            
 
 # Discovery Script section - Discovery scripts get this
 #=================================================================================
 # Load SCOM Discovery module
 $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
-#=================================================================================	
+#=================================================================================               
 
 
 # Begin MAIN script section
 #=================================================================================
 #Get the Listener from QueueManager
-$Lcmd = "cmd /c 'echo Display listener(*) | runmqsc $QueueManagerName'"
+$Lcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display listener(*) | runmqsc $QueueManagerName'"
+$Lout = Invoke-Expression "$Lcmd"
 
-$Lout = Invoke-Expression $Lcmd
 FOREACH ($LLine in $Lout)
 {
   $Lmatch = $LLine | Select-String -Pattern 'LISTENER\(' -CaseSensitive
@@ -1791,7 +1789,7 @@ FOREACH ($LLine in $Lout)
     $instance.AddProperty("$MPElement[Name='Windows!Microsoft.Windows.Computer']/PrincipalName$",$ComputerName)
     $instance.AddProperty("$MPElement[Name='IBM.MQ.QueueManager']/QueueManagerName$",$QueueManagerName)
     $instance.AddProperty("$MPElement[Name='IBM.MQ.Listener']/ListenerName$",$ListenerName)
-    $instance.AddProperty("$MPElement[Name='IBM.MQ.Listener']/QueueManagerName$",$QueueManagerName)	
+    $instance.AddProperty("$MPElement[Name='IBM.MQ.Listener']/QueueManagerName$",$QueueManagerName)               
     $instance.AddProperty("$MPElement[Name='System!System.Entity']/DisplayName$",$ListenerName)
     $DiscoveryData.AddInstance($instance)
   }
@@ -1814,51 +1812,55 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 #=================================================================================
 # End of script
 </ScriptBody>
-				  <Parameters>
-					<Parameter>
-					  <Name>SourceID</Name>
-					  <Value>$MPElement$</Value>
-					</Parameter>
-					<Parameter>
-					  <Name>ManagedEntityID</Name>
-					  <Value>$Target/Id$</Value>
-					</Parameter>
-					<Parameter>
-					  <Name>ComputerName</Name>
-					  <Value>$Target/Host/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
-					</Parameter>
-					<Parameter>
-					  <Name>QueueManagerName</Name>
-					  <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
-					</Parameter>					
-				  </Parameters>
-				  <TimeoutSeconds>300</TimeoutSeconds>
-				</DataSource>				
-			</Discovery>
-			<Discovery ID="IBM.MQ.Queue.Discovery" Enabled="true" Target="IBM.MQ.QueueManager" ConfirmDelivery="false" Remotable="true" Priority="Normal">
-				<Category>Discovery</Category>
-				<DiscoveryTypes>
-					<DiscoveryClass TypeID="IBM.MQ.Queue">
-						<Property TypeID="IBM.MQ.Queue" PropertyID="QueueName" />
-						<Property TypeID="IBM.MQ.Queue" PropertyID="QueueManagerName" />
-						<Property TypeID="IBM.MQ.Queue" PropertyID="TYPE" />
-						<Property TypeID="IBM.MQ.Queue" PropertyID="DESCR" />
-						<Property TypeID="IBM.MQ.Queue" PropertyID="MAXDEPTH" />
-						<Property TypeID="IBM.MQ.Queue" PropertyID="MAXMSGL" />						
-					</DiscoveryClass>
-				</DiscoveryTypes>
-				<DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
-				  <IntervalSeconds>86401</IntervalSeconds>
-				  <SyncTime />
-				  <ScriptName>IBM.MQ.Queue.Discovery.ps1</ScriptName>
-				  <ScriptBody>
+          <Parameters>
+            <Parameter>
+              <Name>SourceID</Name>
+              <Value>$MPElement$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>ManagedEntityID</Name>
+              <Value>$Target/Id$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>ComputerName</Name>
+              <Value>$Target/Host/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>QueueManagerName</Name>
+              <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>InstallPath</Name>
+              <Value>$Target/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
+            </Parameter>
+          </Parameters>
+          <TimeoutSeconds>300</TimeoutSeconds>
+        </DataSource>
+      </Discovery>
+      <Discovery ID="IBM.MQ.Queue.Discovery" Enabled="true" Target="IBM.MQ.QueueManager" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="IBM.MQ.Queue">
+            <Property TypeID="IBM.MQ.Queue" PropertyID="QueueName" />
+            <Property TypeID="IBM.MQ.Queue" PropertyID="QueueManagerName" />
+            <Property TypeID="IBM.MQ.Queue" PropertyID="TYPE" />
+            <Property TypeID="IBM.MQ.Queue" PropertyID="DESCR" />
+            <Property TypeID="IBM.MQ.Queue" PropertyID="MAXDEPTH" />
+            <Property TypeID="IBM.MQ.Queue" PropertyID="MAXMSGL" />
+          </DiscoveryClass>
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
+          <IntervalSeconds>86401</IntervalSeconds>
+          <SyncTime />
+          <ScriptName>IBM.MQ.Queue.Discovery.ps1</ScriptName>
+          <ScriptBody>
 #=================================================================================
 #  IBM MQ Queue Discovery Script
 #
 #  Author: Kevin Holman
 #  v1.5
 #=================================================================================
-param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName)
+param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName,$InstallPath)
 
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
@@ -1892,19 +1894,19 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #Log script event that we are starting task
 $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript is starting. `nRunning as ($whoami).")
 #=================================================================================
-			
+                                            
 
 # Discovery Script section - Discovery scripts get this
 #=================================================================================
 # Load SCOM Discovery module
 $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
-#=================================================================================	
+#=================================================================================               
 
 
 # Begin MAIN script section
 #=================================================================================
   #Get the queues from QueueManager
-  $Qcmd = "cmd /c 'echo Display QL(*) | runmqsc $QueueManagerName'"
+  $Qcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display QL(*) | runmqsc $QueueManagerName'"
   # Write-Host "Getting Queues from ($QueueManagerName) using $Qcmd"
   $Qout = Invoke-Expression $Qcmd
   
@@ -1935,7 +1937,9 @@ $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
       {
         #Get Queue Properties
         $QPropcmd = "cmd /c `"echo Display Queue ('$QueueName') TYPE DESCR MAXDEPTH MAXMSGL | runmqsc $QueueManagerName`""
-        $QPropout = Invoke-Expression $QPropcmd
+        Set-Location "$($InstallPath)\bin"
+                              $QPropout = . "$QPropcmd"
+                              
 
         FOREACH ($QPropLine in $QPropout)
         {
@@ -2024,48 +2028,52 @@ $EndTime = Get-Date
 $ScriptTime = ($EndTime - $StartTime).TotalSeconds
 $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Runtime: ($ScriptTime) seconds.")
 #=================================================================================
-# End of script				  
+# End of script                                                  
 </ScriptBody>
-				  <Parameters>
-					<Parameter>
-					  <Name>SourceID</Name>
-					  <Value>$MPElement$</Value>
-					</Parameter>
-					<Parameter>
-					  <Name>ManagedEntityID</Name>
-					  <Value>$Target/Id$</Value>
-					</Parameter>
-					<Parameter>
-					  <Name>ComputerName</Name>
-					  <Value>$Target/Host/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
-					</Parameter>
-					<Parameter>
-					  <Name>QueueManagerName</Name>
-					  <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
-					</Parameter>					
-				  </Parameters>
-				  <TimeoutSeconds>300</TimeoutSeconds>
-				</DataSource>				
-			</Discovery>			
-			<Discovery ID="IBM.MQ.QueueManager.Discovery" Enabled="true" Target="IBM.MQ.Server" ConfirmDelivery="false" Remotable="true" Priority="Normal">
-				<Category>Discovery</Category>
-				<DiscoveryTypes>
-					<DiscoveryClass TypeID="IBM.MQ.QueueManager">
-						<Property TypeID="IBM.MQ.QueueManager" PropertyID="QueueManagerName" />
-					</DiscoveryClass>
-				</DiscoveryTypes>
-				<DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
-				  <IntervalSeconds>86400</IntervalSeconds>
-				  <SyncTime />
-				  <ScriptName>IBM.MQ.QueueManager.Discovery.ps1</ScriptName>
-				  <ScriptBody>
+          <Parameters>
+            <Parameter>
+              <Name>SourceID</Name>
+              <Value>$MPElement$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>ManagedEntityID</Name>
+              <Value>$Target/Id$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>ComputerName</Name>
+              <Value>$Target/Host/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>QueueManagerName</Name>
+              <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>InstallPath</Name>
+              <Value>$Target/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
+            </Parameter>
+          </Parameters>
+          <TimeoutSeconds>300</TimeoutSeconds>
+        </DataSource>
+      </Discovery>
+      <Discovery ID="IBM.MQ.QueueManager.Discovery" Enabled="true" Target="IBM.MQ.Server" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="IBM.MQ.QueueManager">
+            <Property TypeID="IBM.MQ.QueueManager" PropertyID="QueueManagerName" />
+          </DiscoveryClass>
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
+          <IntervalSeconds>86400</IntervalSeconds>
+          <SyncTime />
+          <ScriptName>IBM.MQ.QueueManager.Discovery.ps1</ScriptName>
+          <ScriptBody>
 #=================================================================================
 #  Discover IBM MQ QueueManager
 #
 #  Author: Kevin Holman
 #  v1.1
 #=================================================================================
-param($SourceId,$ManagedEntityId,$ComputerName)
+param($SourceId,$ManagedEntityId,$ComputerName,$InstallPath)
 
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
@@ -2096,20 +2104,20 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #Log script event that we are starting task
 $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script is starting. `n Running as ($whoami).")
 #=================================================================================
-			
+                                            
 
 # Discovery Script section - Discovery scripts get this
 #=================================================================================
 # Load SCOM Discovery module
 $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
-#=================================================================================	
+#=================================================================================               
 
 
 # Begin MAIN script section
 #=================================================================================
 #Get the Queue Managers
 $QMGRcmd = "dspmq"
-$QMGRcmdOut = Invoke-Expression $QMGRcmd
+$QMGRcmdOut = . "$($InstallPath)\bin\$QMGRcmd"
 FOREACH ($QMGRLine in $QMGRcmdOut)
 {
   $QMGRLineSplit = $QMGRLine.Split("(,)")
@@ -2140,734 +2148,748 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 #=================================================================================
 # End of script
 </ScriptBody>
-				  <Parameters>
-					<Parameter>
-					  <Name>SourceID</Name>
-					  <Value>$MPElement$</Value>
-					</Parameter>
-					<Parameter>
-					  <Name>ManagedEntityID</Name>
-					  <Value>$Target/Id$</Value>
-					</Parameter>
-					<Parameter>
-					  <Name>ComputerName</Name>
-					  <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
-					</Parameter>
-				  </Parameters>
-				  <TimeoutSeconds>300</TimeoutSeconds>
-				</DataSource>				
-			</Discovery>
-			<Discovery ID="IBM.MQ.Server.Discovery" Enabled="true" Target="Windows!Microsoft.Windows.Server.OperatingSystem" ConfirmDelivery="false" Remotable="true" Priority="Normal">
-				<Category>Discovery</Category>
-				<DiscoveryTypes>
-					<DiscoveryClass TypeID="IBM.MQ.Server">
-						<Property TypeID="IBM.MQ.Server" PropertyID="Version" />
-						<Property TypeID="IBM.MQ.Server" PropertyID="InstallPath" />
-					</DiscoveryClass>					
-				</DiscoveryTypes>
-				<DataSource ID="DS" TypeID="Windows!Microsoft.Windows.FilteredRegistryDiscoveryProvider">
-					<ComputerName>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/NetworkName$</ComputerName>
-					<RegistryAttributeDefinitions>
-						<RegistryAttributeDefinition>
-							<AttributeName>MQ_ServiceExists</AttributeName>
-							<Path>SYSTEM\CurrentControlSet\Services\MQ_Installation1</Path>
-							<PathType>0</PathType>
-							<AttributeType>0</AttributeType>
-						</RegistryAttributeDefinition>
-						<RegistryAttributeDefinition>
-							<AttributeName>MQ_Version</AttributeName>
-							<Path>SOFTWARE\IBM\WebSphere MQ\Installation\Installation1\VRMF</Path>
-							<PathType>1</PathType>
-							<AttributeType>1</AttributeType>
-						</RegistryAttributeDefinition>
-						<RegistryAttributeDefinition>
-							<AttributeName>MQ_InstallPath</AttributeName>
-							<Path>SOFTWARE\IBM\WebSphere MQ\Installation\Installation1\FilePath</Path>
-							<PathType>1</PathType>
-							<AttributeType>1</AttributeType>
-						</RegistryAttributeDefinition>						
-					</RegistryAttributeDefinitions>
-					<Frequency>14400</Frequency>
-					<ClassId>$MPElement[Name="IBM.MQ.Server"]$</ClassId>
-					<InstanceSettings>
-						<Settings>
-							<Setting>
-								<Name>$MPElement[Name="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Name>
-								<Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
-							</Setting>
-							<Setting>
-								<Name>$MPElement[Name="System!System.Entity"]/DisplayName$</Name>
-								<Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
-							</Setting>
-							<Setting>
-								<Name>$MPElement[Name="IBM.MQ.Server"]/Version$</Name>
-								<Value>$Data/Values/MQ_Version$</Value>
-							</Setting>
-							<Setting>
-								<Name>$MPElement[Name="IBM.MQ.Server"]/InstallPath$</Name>
-								<Value>$Data/Values/MQ_InstallPath$</Value>
-							</Setting>							
-						</Settings>
-					</InstanceSettings>
-					<Expression>
-						<SimpleExpression>
-							<ValueExpression>
-								<XPathQuery Type="Boolean">Values/MQ_ServiceExists</XPathQuery>
-							</ValueExpression>
-							<Operator>Equal</Operator>
-							<ValueExpression>
-								<Value Type="Boolean">true</Value>
-							</ValueExpression>
-						</SimpleExpression>
-					</Expression>
-				</DataSource>
-			</Discovery>
-		</Discoveries>
-		<Rules>
-		  <Rule ID="IBM.MQ.QueueDepth.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
-			<Category>PerformanceCollection</Category>
-			<DataSources>
-			  <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-				<IntervalSeconds>901</IntervalSeconds>
-				<TimeoutSeconds>300</TimeoutSeconds>
-				<QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-				<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-			  </DataSource>
-			</DataSources>
-			<ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
-			  <ObjectName>IBMMQ</ObjectName>
-			  <CounterName>QueueDepth</CounterName>
-			  <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
-			  <Value>$Data/Property[@Name='QueueDepth']$</Value>
-			</ConditionDetection>
-			<WriteActions>
-			  <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />  <!-- Can be optional - collect this data to the Operations Database.  -->
-			  <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />  <!-- Can be optional - collect this data to the Data Warehouse Database -->
-			</WriteActions>
-		  </Rule>
-		  <Rule ID="IBM.MQ.QueuePercentUsed.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
-			<Category>PerformanceCollection</Category>
-			<DataSources>
-			  <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-				<IntervalSeconds>901</IntervalSeconds>
-				<TimeoutSeconds>300</TimeoutSeconds>
-				<QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-				<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-			  </DataSource>
-			</DataSources>
-			<ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
-			  <ObjectName>IBMMQ</ObjectName>
-			  <CounterName>QueuePercentUsed</CounterName>
-			  <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
-			  <Value>$Data/Property[@Name='QueuePercentUsed']$</Value>
-			</ConditionDetection>
-			<WriteActions>
-			  <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />  <!-- Can be optional - collect this data to the Operations Database.  -->
-			  <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />  <!-- Can be optional - collect this data to the Data Warehouse Database -->
-			</WriteActions>
-		  </Rule>		  
-		  <Rule ID="IBM.MQ.QueueIPPROCS.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
-			<Category>PerformanceCollection</Category>
-			<DataSources>
-			  <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-				<IntervalSeconds>901</IntervalSeconds>
-				<TimeoutSeconds>300</TimeoutSeconds>
-				<QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-				<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-			  </DataSource>
-			</DataSources>
-			<ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
-			  <ObjectName>IBMMQ</ObjectName>
-			  <CounterName>IPPROCS</CounterName>
-			  <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
-			  <Value>$Data/Property[@Name='IPPROCS']$</Value>
-			</ConditionDetection>
-			<WriteActions>
-			  <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />  <!-- Can be optional - collect this data to the Operations Database.  -->
-			  <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />  <!-- Can be optional - collect this data to the Data Warehouse Database -->
-			</WriteActions>
-		  </Rule>
-		  <Rule ID="IBM.MQ.QueueOPPROCS.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
-			<Category>PerformanceCollection</Category>
-			<DataSources>
-			  <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-				<IntervalSeconds>901</IntervalSeconds>
-				<TimeoutSeconds>300</TimeoutSeconds>
-				<QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-				<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-			  </DataSource>
-			</DataSources>
-			<ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
-			  <ObjectName>IBMMQ</ObjectName>
-			  <CounterName>OPPROCS</CounterName>
-			  <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
-			  <Value>$Data/Property[@Name='OPPROCS']$</Value>
-			</ConditionDetection>
-			<WriteActions>
-			  <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />  <!-- Can be optional - collect this data to the Operations Database.  -->
-			  <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />  <!-- Can be optional - collect this data to the Data Warehouse Database -->
-			</WriteActions>
-		  </Rule>
-		  <Rule ID="IBM.MQ.ListenerSessions.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Listener" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
-			<Category>PerformanceCollection</Category>
-			<DataSources>
-			  <DataSource ID="DS" TypeID="IBM.MQ.ListenerPerformance.Filtered.DS">
-				<IntervalSeconds>904</IntervalSeconds>
-				<TimeoutSeconds>300</TimeoutSeconds>
-				<ListenerName>$Target/Property[Type="IBM.MQ.Listener"]/ListenerName$</ListenerName>
-				<QueueManagerName>$Target/Property[Type="IBM.MQ.Listener"]/QueueManagerName$</QueueManagerName>
-			  </DataSource>
-			</DataSources>
-			<ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
-			  <ObjectName>IBMMQ</ObjectName>
-			  <CounterName>Sessions</CounterName>
-			  <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='ListenerName']$</InstanceName>
-			  <Value>$Data/Property[@Name='LSessionsValue']$</Value>
-			</ConditionDetection>
-			<WriteActions>
-			  <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />  <!-- Can be optional - collect this data to the Operations Database.  -->
-			  <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />  <!-- Can be optional - collect this data to the Data Warehouse Database -->
-			</WriteActions>
-		  </Rule>
-		</Rules>
-		<Monitors>
-			<UnitMonitor ID="IBM.MQ.ChannelStatus.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Channel" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.ChannelStatus.Monitor.MonitorType" ConfirmDelivery="false">
-				<Category>AvailabilityHealth</Category>
-				<AlertSettings AlertMessage="IBM.MQ.ChannelStatus.Monitor.AlertMessage">
-					<AlertOnState>Error</AlertOnState>
-					<AutoResolve>true</AutoResolve>
-					<AlertPriority>Normal</AlertPriority>
-					<AlertSeverity>MatchMonitorHealth</AlertSeverity>
-					<AlertParameters>
-						<AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
-						<AlertParameter2>$Data/Context/Property[@Name="ChannelName"]$</AlertParameter2>
-						<AlertParameter3>$Data/Context/Property[@Name="CStatus"]$</AlertParameter3>
-					</AlertParameters>
-				</AlertSettings>
-				<OperationalStates>
-					<OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
-					<OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
-				</OperationalStates>
-				<Configuration>
-					<IntervalSeconds>903</IntervalSeconds>
-                    <ChannelName>$Target/Property[Type="IBM.MQ.Channel"]/ChannelName$</ChannelName>
-					<QueueManagerName>$Target/Property[Type="IBM.MQ.Channel"]/QueueManagerName$</QueueManagerName>
-					<TimeoutSeconds>300</TimeoutSeconds>
-				</Configuration>
-			</UnitMonitor>			
-			<UnitMonitor ID="IBM.MQ.QueueDepth.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Queue" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueueDepth.Monitor.MonitorType" ConfirmDelivery="false">
-				<Category>AvailabilityHealth</Category>
-				<AlertSettings AlertMessage="IBM.MQ.QueueDepth.Monitor.AlertMessage">
-					<AlertOnState>Error</AlertOnState>
-					<AutoResolve>true</AutoResolve>
-					<AlertPriority>Normal</AlertPriority>
-					<AlertSeverity>MatchMonitorHealth</AlertSeverity>
-					<AlertParameters>
-						<AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
-						<AlertParameter2>$Data/Context/Property[@Name="QueueName"]$</AlertParameter2>
-						<AlertParameter3>$Data/Context/Property[@Name="QueueDepth"]$</AlertParameter3>
-					</AlertParameters>
-				</AlertSettings>
-				<OperationalStates>
-					<OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
-					<OperationalState ID="Warning" MonitorTypeStateID="Warning" HealthState="Warning" />
-					<OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
-				</OperationalStates>
-				<Configuration>
-					<IntervalSeconds>901</IntervalSeconds>
-					<TimeoutSeconds>300</TimeoutSeconds>
-                    <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-					<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-					<WarningThreshold>10</WarningThreshold>
-					<CriticalThreshold>50</CriticalThreshold>
-				</Configuration>
-			</UnitMonitor>
-			<UnitMonitor ID="IBM.MQ.QueuePercentUsed.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Queue" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueuePercentUsed.Monitor.MonitorType" ConfirmDelivery="false">
-				<Category>AvailabilityHealth</Category>
-				<AlertSettings AlertMessage="IBM.MQ.QueuePercentUsed.Monitor.AlertMessage">
-					<AlertOnState>Error</AlertOnState>
-					<AutoResolve>true</AutoResolve>
-					<AlertPriority>Normal</AlertPriority>
-					<AlertSeverity>MatchMonitorHealth</AlertSeverity>
-					<AlertParameters>
-						<AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
-						<AlertParameter2>$Data/Context/Property[@Name="QueueName"]$</AlertParameter2>
-						<AlertParameter3>$Data/Context/Property[@Name="QueueDepth"]$</AlertParameter3>
-						<AlertParameter4>$Data/Context/Property[@Name="QueuePercentUsed"]$</AlertParameter4>						
-					</AlertParameters>
-				</AlertSettings>
-				<OperationalStates>
-					<OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
-					<OperationalState ID="Warning" MonitorTypeStateID="Warning" HealthState="Warning" />
-					<OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
-				</OperationalStates>
-				<Configuration>
-					<IntervalSeconds>901</IntervalSeconds>
-					<TimeoutSeconds>300</TimeoutSeconds>
-                    <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-					<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-					<WarningThreshold>50</WarningThreshold>
-					<CriticalThreshold>75</CriticalThreshold>
-				</Configuration>
-			</UnitMonitor>			
-			<UnitMonitor ID="IBM.MQ.ListenerStatus.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Listener" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.ListenerStatus.Monitor.MonitorType" ConfirmDelivery="false">
-				<Category>AvailabilityHealth</Category>
-				<AlertSettings AlertMessage="IBM.MQ.ListenerStatus.Monitor.AlertMessage">
-					<AlertOnState>Error</AlertOnState>
-					<AutoResolve>true</AutoResolve>
-					<AlertPriority>Normal</AlertPriority>
-					<AlertSeverity>MatchMonitorHealth</AlertSeverity>
-					<AlertParameters>
-						<AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
-						<AlertParameter2>$Data/Context/Property[@Name="ListenerName"]$</AlertParameter2>
-						<AlertParameter3>$Data/Context/Property[@Name="LStatus"]$</AlertParameter3>
-					</AlertParameters>
-				</AlertSettings>
-				<OperationalStates>
-					<OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
-					<OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
-				</OperationalStates>
-				<Configuration>
-					<IntervalSeconds>902</IntervalSeconds>
-                    <ListenerName>$Target/Property[Type="IBM.MQ.Listener"]/ListenerName$</ListenerName>
-					<QueueManagerName>$Target/Property[Type="IBM.MQ.Listener"]/QueueManagerName$</QueueManagerName>
-					<TimeoutSeconds>300</TimeoutSeconds>
-				</Configuration>
-			</UnitMonitor>				
-			<UnitMonitor ID="IBM.MQ.MQ_Installation1.Service.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Server" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="Windows!Microsoft.Windows.CheckNTServiceStateMonitorType" ConfirmDelivery="false">
-				<Category>AvailabilityHealth</Category>
-				<AlertSettings AlertMessage="IBM.MQ.MQ_Installation1.Service.Monitor.AlertMessage">
-					<AlertOnState>Error</AlertOnState>
-					<AutoResolve>true</AutoResolve>
-					<AlertPriority>High</AlertPriority>
-					<AlertSeverity>Error</AlertSeverity>
-					<AlertParameters>
-						<AlertParameter1>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/NetbiosComputerName$</AlertParameter1>
-					</AlertParameters>
-				</AlertSettings>
-				<OperationalStates>
-					<OperationalState ID="Running" MonitorTypeStateID="Running" HealthState="Success" />
-					<OperationalState ID="NotRunning" MonitorTypeStateID="NotRunning" HealthState="Error" />
-				</OperationalStates>
-				<Configuration>
-					<ComputerName />
-					<ServiceName>MQ_Installation1</ServiceName>
-					<CheckStartupType />
-				</Configuration>
-			</UnitMonitor>
-			<UnitMonitor ID="IBM.MQ.QueueIPPROCS.Monitor" Accessibility="Public" Enabled="false" Target="IBM.MQ.Queue" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueueIPPROCS.Monitor.MonitorType" ConfirmDelivery="false">
-				<Category>AvailabilityHealth</Category>
-				<AlertSettings AlertMessage="IBM.MQ.QueueIPPROCS.Monitor.AlertMessage">
-					<AlertOnState>Error</AlertOnState>
-					<AutoResolve>true</AutoResolve>
-					<AlertPriority>Normal</AlertPriority>
-					<AlertSeverity>MatchMonitorHealth</AlertSeverity>
-					<AlertParameters>
-						<AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
-						<AlertParameter2>$Data/Context/Property[@Name="QueueName"]$</AlertParameter2>
-						<AlertParameter3>$Data/Context/Property[@Name="IPPROCS"]$</AlertParameter3>
-					</AlertParameters>
-				</AlertSettings>
-				<OperationalStates>
-					<OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
-					<OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
-				</OperationalStates>
-				<Configuration>
-					<IntervalSeconds>901</IntervalSeconds>
-					<TimeoutSeconds>300</TimeoutSeconds>
-                    <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-					<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-				</Configuration>
-			</UnitMonitor>			
-			<UnitMonitor ID="IBM.MQ.QueueManagerStatus.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueueManagerStatus.Monitor.MonitorType" ConfirmDelivery="false">
-				<Category>AvailabilityHealth</Category>
-				<AlertSettings AlertMessage="IBM.MQ.QueueManagerStatus.Monitor.AlertMessage">
-					<AlertOnState>Error</AlertOnState>
-					<AutoResolve>true</AutoResolve>
-					<AlertPriority>Normal</AlertPriority>
-					<AlertSeverity>MatchMonitorHealth</AlertSeverity>
-					<AlertParameters>
-						<AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
-						<AlertParameter2>$Data/Context/Property[@Name="QMGRStatus"]$</AlertParameter2>
-					</AlertParameters>
-				</AlertSettings>
-				<OperationalStates>
-					<OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
-					<OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
-				</OperationalStates>
-				<Configuration>
-					<IntervalSeconds>904</IntervalSeconds>
-					<QueueManagerName>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</QueueManagerName>
-					<TimeoutSeconds>300</TimeoutSeconds>
-				</Configuration>
-			</UnitMonitor>			
-			<DependencyMonitor ID="IBM.MQ.QueueManagerChannels.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.QueueManager.Hosts.Channel" MemberMonitor="Health!System.Health.AvailabilityState">
-				<Category>Custom</Category>
-				<Algorithm>WorstOf</Algorithm>
-				<MemberUnAvailable>Error</MemberUnAvailable>
-			</DependencyMonitor>
-			<DependencyMonitor ID="IBM.MQ.QueueManagerListeners.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.QueueManager.Hosts.Listener" MemberMonitor="Health!System.Health.AvailabilityState">
-				<Category>Custom</Category>
-				<Algorithm>WorstOf</Algorithm>
-				<MemberUnAvailable>Error</MemberUnAvailable>
-			</DependencyMonitor>
-			<DependencyMonitor ID="IBM.MQ.QueueManagerQueues.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.QueueManager.Hosts.Queue" MemberMonitor="Health!System.Health.AvailabilityState">
-				<Category>Custom</Category>
-				<Algorithm>WorstOf</Algorithm>
-				<MemberUnAvailable>Error</MemberUnAvailable>
-			</DependencyMonitor>
-			<DependencyMonitor ID="IBM.MQ.QueueManagerToServer.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Server" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.Server.Hosts.QueueManager" MemberMonitor="Health!System.Health.AvailabilityState">
-				<Category>Custom</Category>
-				<Algorithm>WorstOf</Algorithm>
-				<MemberUnAvailable>Error</MemberUnAvailable>
-			</DependencyMonitor>
-		</Monitors>
-	</Monitoring>
-	<Presentation>
-		<Views>
-			<View ID="IBM.MQ.Channel.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Channel" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
-				<Category>Custom</Category>
-				<Criteria />
-			</View>
-			<View ID="IBM.MQ.Listeners.Performance.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Listener" TypeID="SC!Microsoft.SystemCenter.PerformanceViewType" Visible="true">
-				<Category>Custom</Category>
-				<Criteria />
-			</View>
-			<View ID="IBM.MQ.Listener.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Listener" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
-				<Category>Custom</Category>
-				<Criteria />
-			</View>
-			<View ID="IBM.MQ.QueueManager.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.QueueManager" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
-				<Category>Custom</Category>
-				<Criteria />
-			</View>
-			<View ID="IBM.MQ.Queue.Performance.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Queue" TypeID="SC!Microsoft.SystemCenter.PerformanceViewType" Visible="true">
-				<Category>Custom</Category>
-				<Criteria />
-			</View>
-			<View ID="IBM.MQ.Queue.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Queue" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
-				<Category>Custom</Category>
-				<Criteria />
-			</View>
-			<View ID="IBM.MQ.Server.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Server" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
-				<Category>Custom</Category>
-				<Criteria />
-			</View>
-			<View ID="IBM.MQ.Server.Alert.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Server" TypeID="SC!Microsoft.SystemCenter.AlertViewType" Visible="true">
-				<Category>Custom</Category>
-				<Criteria>
-					<ResolutionState>
-						<StateRange Operator="NotEquals">255</StateRange>
-					</ResolutionState>
-				</Criteria>
-			</View>
-		</Views>
-		<Folders>
-			<Folder ID="IBM.MQ.Channel.Folder" Accessibility="Internal" ParentFolder="IBM.MQ.Root.Folder" />
-			<Folder ID="IBM.MQ.Root.Folder" Accessibility="Internal" ParentFolder="SC!Microsoft.SystemCenter.Monitoring.ViewFolder.Root" />
-			<Folder ID="IBM.MQ.Listener.Folder" Accessibility="Internal" ParentFolder="IBM.MQ.Root.Folder" />
-			<Folder ID="IBM.MQ.Queues.Folder" Accessibility="Internal" ParentFolder="IBM.MQ.Root.Folder" />
-		</Folders>
-		<FolderItems>
-			<FolderItem ElementID="IBM.MQ.Channel.State.View" ID="IBM.MQ.Channel.State.View.FolderItem" Folder="IBM.MQ.Channel.Folder" />
-			<FolderItem ElementID="IBM.MQ.Listeners.Performance.View" ID="IBM.MQ.Listeners.Performance.View.FolderItem" Folder="IBM.MQ.Listener.Folder" />
-			<FolderItem ElementID="IBM.MQ.Listener.State.View" ID="IBM.MQ.Listener.State.View.FolderItem" Folder="IBM.MQ.Listener.Folder" />
-			<FolderItem ElementID="IBM.MQ.QueueManager.State.View" ID="IBM.MQ.QueueManager.State.View.FolderItem" Folder="IBM.MQ.Root.Folder" />
-			<FolderItem ElementID="IBM.MQ.Queue.Performance.View" ID="IBM.MQ.Queue.Performance.View.FolderItem" Folder="IBM.MQ.Queues.Folder" />
-			<FolderItem ElementID="IBM.MQ.Queue.State.View" ID="IBM.MQ.Queue.State.View.FolderItem" Folder="IBM.MQ.Queues.Folder" />
-			<FolderItem ElementID="IBM.MQ.Server.State.View" ID="IBM.MQ.Server.State.View.FolderItem" Folder="IBM.MQ.Root.Folder" />
-			<FolderItem ElementID="IBM.MQ.Server.Alert.View" ID="IBM.MQ.Server.Alert.View.FolderItem" Folder="IBM.MQ.Root.Folder" />
-		</FolderItems>
-		<StringResources>
-			<StringResource ID="IBM.MQ.ChannelStatus.Monitor.AlertMessage" />
-			<StringResource ID="IBM.MQ.ListenerStatus.Monitor.AlertMessage" />
-			<StringResource ID="IBM.MQ.MQ_Installation1.Service.Monitor.AlertMessage" />
-			<StringResource ID="IBM.MQ.QueueManagerStatus.Monitor.AlertMessage" />
-			<StringResource ID="IBM.MQ.QueueDepth.Monitor.AlertMessage" />
-			<StringResource ID="IBM.MQ.QueuePercentUsed.Monitor.AlertMessage" />			
-			<StringResource ID="IBM.MQ.QueueIPPROCS.Monitor.AlertMessage" />
-		</StringResources>
-	</Presentation>
-	<LanguagePacks>
-		<LanguagePack ID="ENU" IsDefault="true">
-			<DisplayStrings>
-				<DisplayString ElementID="IBM.MQ">
-					<Name>IBM MQ</Name>
-					<Description>IBM WebSphere MQ Management Pack</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Channel">
-					<Name>Channel</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Channel.Discovery">
-					<Name>IBM MQ Channel Discovery</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Channel.Folder">
-					<Name>Channels</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Channel.State.View">
-					<Name>Channel State</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Channel" SubElementID="ChannelName">
-					<Name>Channel Name</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Channel" SubElementID="ChannelType">
-					<Name>Channel Type</Name>
-				</DisplayString>				
-				<DisplayString ElementID="IBM.MQ.Channel" SubElementID="QueueManagerName">
-					<Name>Queue Manager Name</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor">
-					<Name>IBM MQ Channel Status Monitor</Name>
-					<Description></Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor.AlertMessage">
-					<Name>IBM MQ Channel Status Alert</Name>
-					<Description>IBM MQ Channel Status is not Running.
+          <Parameters>
+            <Parameter>
+              <Name>SourceID</Name>
+              <Value>$MPElement$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>ManagedEntityID</Name>
+              <Value>$Target/Id$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>ComputerName</Name>
+              <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+            </Parameter>
+            <Parameter>
+              <Name>InstallPath</Name>
+              <Value>$Target/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
+            </Parameter>
+          </Parameters>
+          <TimeoutSeconds>300</TimeoutSeconds>
+        </DataSource>
+      </Discovery>
+      <Discovery ID="IBM.MQ.Server.Discovery" Enabled="true" Target="Windows!Microsoft.Windows.Server.OperatingSystem" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+        <Category>Discovery</Category>
+        <DiscoveryTypes>
+          <DiscoveryClass TypeID="IBM.MQ.Server">
+            <Property TypeID="IBM.MQ.Server" PropertyID="Version" />
+            <Property TypeID="IBM.MQ.Server" PropertyID="InstallPath" />
+          </DiscoveryClass>
+        </DiscoveryTypes>
+        <DataSource ID="DS" TypeID="Windows!Microsoft.Windows.FilteredRegistryDiscoveryProvider">
+          <ComputerName>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/NetworkName$</ComputerName>
+          <RegistryAttributeDefinitions>
+            <RegistryAttributeDefinition>
+              <AttributeName>MQ_ServiceExists</AttributeName>
+              <Path>SYSTEM\CurrentControlSet\Services\MQ_Installation1</Path>
+              <PathType>0</PathType>
+              <AttributeType>0</AttributeType>
+            </RegistryAttributeDefinition>
+            <RegistryAttributeDefinition>
+              <AttributeName>MQ_Version</AttributeName>
+              <Path>SOFTWARE\IBM\WebSphere MQ\Installation\Installation1\VRMF</Path>
+              <PathType>1</PathType>
+              <AttributeType>1</AttributeType>
+            </RegistryAttributeDefinition>
+            <RegistryAttributeDefinition>
+              <AttributeName>MQ_InstallPath</AttributeName>
+              <Path>SOFTWARE\IBM\WebSphere MQ\Installation\Installation1\FilePath</Path>
+              <PathType>1</PathType>
+              <AttributeType>1</AttributeType>
+            </RegistryAttributeDefinition>
+          </RegistryAttributeDefinitions>
+          <Frequency>14400</Frequency>
+          <ClassId>$MPElement[Name="IBM.MQ.Server"]$</ClassId>
+          <InstanceSettings>
+            <Settings>
+              <Setting>
+                <Name>$MPElement[Name="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Name>
+                <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name="System!System.Entity"]/DisplayName$</Name>
+                <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name="IBM.MQ.Server"]/Version$</Name>
+                <Value>$Data/Values/MQ_Version$</Value>
+              </Setting>
+              <Setting>
+                <Name>$MPElement[Name="IBM.MQ.Server"]/InstallPath$</Name>
+                <Value>$Data/Values/MQ_InstallPath$</Value>
+              </Setting>
+            </Settings>
+          </InstanceSettings>
+          <Expression>
+            <SimpleExpression>
+              <ValueExpression>
+                <XPathQuery Type="Boolean">Values/MQ_ServiceExists</XPathQuery>
+              </ValueExpression>
+              <Operator>Equal</Operator>
+              <ValueExpression>
+                <Value Type="Boolean">true</Value>
+              </ValueExpression>
+            </SimpleExpression>
+          </Expression>
+        </DataSource>
+      </Discovery>
+    </Discoveries>
+    <Rules>
+      <Rule ID="IBM.MQ.QueueDepth.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+        <Category>PerformanceCollection</Category>
+        <DataSources>
+          <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
+            <IntervalSeconds>901</IntervalSeconds>
+            <TimeoutSeconds>300</TimeoutSeconds>
+            <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+            <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+          </DataSource>
+        </DataSources>
+        <ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
+          <ObjectName>IBMMQ</ObjectName>
+          <CounterName>QueueDepth</CounterName>
+          <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
+          <Value>$Data/Property[@Name='QueueDepth']$</Value>
+        </ConditionDetection>
+        <WriteActions>
+          <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />
+          <!-- Can be optional - collect this data to the Operations Database.  -->
+          <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
+          <!-- Can be optional - collect this data to the Data Warehouse Database -->
+        </WriteActions>
+      </Rule>
+      <Rule ID="IBM.MQ.QueuePercentUsed.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+        <Category>PerformanceCollection</Category>
+        <DataSources>
+          <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
+            <IntervalSeconds>901</IntervalSeconds>
+            <TimeoutSeconds>300</TimeoutSeconds>
+            <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+            <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+          </DataSource>
+        </DataSources>
+        <ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
+          <ObjectName>IBMMQ</ObjectName>
+          <CounterName>QueuePercentUsed</CounterName>
+          <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
+          <Value>$Data/Property[@Name='QueuePercentUsed']$</Value>
+        </ConditionDetection>
+        <WriteActions>
+          <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />
+          <!-- Can be optional - collect this data to the Operations Database.  -->
+          <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
+          <!-- Can be optional - collect this data to the Data Warehouse Database -->
+        </WriteActions>
+      </Rule>
+      <Rule ID="IBM.MQ.QueueIPPROCS.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+        <Category>PerformanceCollection</Category>
+        <DataSources>
+          <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
+            <IntervalSeconds>901</IntervalSeconds>
+            <TimeoutSeconds>300</TimeoutSeconds>
+            <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+            <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+          </DataSource>
+        </DataSources>
+        <ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
+          <ObjectName>IBMMQ</ObjectName>
+          <CounterName>IPPROCS</CounterName>
+          <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
+          <Value>$Data/Property[@Name='IPPROCS']$</Value>
+        </ConditionDetection>
+        <WriteActions>
+          <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />
+          <!-- Can be optional - collect this data to the Operations Database.  -->
+          <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
+          <!-- Can be optional - collect this data to the Data Warehouse Database -->
+        </WriteActions>
+      </Rule>
+      <Rule ID="IBM.MQ.QueueOPPROCS.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+        <Category>PerformanceCollection</Category>
+        <DataSources>
+          <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
+            <IntervalSeconds>901</IntervalSeconds>
+            <TimeoutSeconds>300</TimeoutSeconds>
+            <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+            <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+          </DataSource>
+        </DataSources>
+        <ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
+          <ObjectName>IBMMQ</ObjectName>
+          <CounterName>OPPROCS</CounterName>
+          <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
+          <Value>$Data/Property[@Name='OPPROCS']$</Value>
+        </ConditionDetection>
+        <WriteActions>
+          <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />
+          <!-- Can be optional - collect this data to the Operations Database.  -->
+          <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
+          <!-- Can be optional - collect this data to the Data Warehouse Database -->
+        </WriteActions>
+      </Rule>
+      <Rule ID="IBM.MQ.ListenerSessions.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Listener" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+        <Category>PerformanceCollection</Category>
+        <DataSources>
+          <DataSource ID="DS" TypeID="IBM.MQ.ListenerPerformance.Filtered.DS">
+            <IntervalSeconds>904</IntervalSeconds>
+            <TimeoutSeconds>300</TimeoutSeconds>
+            <ListenerName>$Target/Property[Type="IBM.MQ.Listener"]/ListenerName$</ListenerName>
+            <QueueManagerName>$Target/Property[Type="IBM.MQ.Listener"]/QueueManagerName$</QueueManagerName>
+          </DataSource>
+        </DataSources>
+        <ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
+          <ObjectName>IBMMQ</ObjectName>
+          <CounterName>Sessions</CounterName>
+          <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='ListenerName']$</InstanceName>
+          <Value>$Data/Property[@Name='LSessionsValue']$</Value>
+        </ConditionDetection>
+        <WriteActions>
+          <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />
+          <!-- Can be optional - collect this data to the Operations Database.  -->
+          <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
+          <!-- Can be optional - collect this data to the Data Warehouse Database -->
+        </WriteActions>
+      </Rule>
+    </Rules>
+    <Monitors>
+      <UnitMonitor ID="IBM.MQ.ChannelStatus.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Channel" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.ChannelStatus.Monitor.MonitorType" ConfirmDelivery="false">
+        <Category>AvailabilityHealth</Category>
+        <AlertSettings AlertMessage="IBM.MQ.ChannelStatus.Monitor.AlertMessage">
+          <AlertOnState>Error</AlertOnState>
+          <AutoResolve>true</AutoResolve>
+          <AlertPriority>Normal</AlertPriority>
+          <AlertSeverity>MatchMonitorHealth</AlertSeverity>
+          <AlertParameters>
+            <AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
+            <AlertParameter2>$Data/Context/Property[@Name="ChannelName"]$</AlertParameter2>
+            <AlertParameter3>$Data/Context/Property[@Name="CStatus"]$</AlertParameter3>
+          </AlertParameters>
+        </AlertSettings>
+        <OperationalStates>
+          <OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
+          <OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
+        </OperationalStates>
+        <Configuration>
+          <IntervalSeconds>903</IntervalSeconds>
+          <ChannelName>$Target/Property[Type="IBM.MQ.Channel"]/ChannelName$</ChannelName>
+          <QueueManagerName>$Target/Property[Type="IBM.MQ.Channel"]/QueueManagerName$</QueueManagerName>
+          <TimeoutSeconds>300</TimeoutSeconds>
+        </Configuration>
+      </UnitMonitor>
+      <UnitMonitor ID="IBM.MQ.QueueDepth.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Queue" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueueDepth.Monitor.MonitorType" ConfirmDelivery="false">
+        <Category>AvailabilityHealth</Category>
+        <AlertSettings AlertMessage="IBM.MQ.QueueDepth.Monitor.AlertMessage">
+          <AlertOnState>Error</AlertOnState>
+          <AutoResolve>true</AutoResolve>
+          <AlertPriority>Normal</AlertPriority>
+          <AlertSeverity>MatchMonitorHealth</AlertSeverity>
+          <AlertParameters>
+            <AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
+            <AlertParameter2>$Data/Context/Property[@Name="QueueName"]$</AlertParameter2>
+            <AlertParameter3>$Data/Context/Property[@Name="QueueDepth"]$</AlertParameter3>
+          </AlertParameters>
+        </AlertSettings>
+        <OperationalStates>
+          <OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
+          <OperationalState ID="Warning" MonitorTypeStateID="Warning" HealthState="Warning" />
+          <OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
+        </OperationalStates>
+        <Configuration>
+          <IntervalSeconds>901</IntervalSeconds>
+          <TimeoutSeconds>300</TimeoutSeconds>
+          <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+          <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+          <WarningThreshold>10</WarningThreshold>
+          <CriticalThreshold>50</CriticalThreshold>
+        </Configuration>
+      </UnitMonitor>
+      <UnitMonitor ID="IBM.MQ.QueuePercentUsed.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Queue" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueuePercentUsed.Monitor.MonitorType" ConfirmDelivery="false">
+        <Category>AvailabilityHealth</Category>
+        <AlertSettings AlertMessage="IBM.MQ.QueuePercentUsed.Monitor.AlertMessage">
+          <AlertOnState>Error</AlertOnState>
+          <AutoResolve>true</AutoResolve>
+          <AlertPriority>Normal</AlertPriority>
+          <AlertSeverity>MatchMonitorHealth</AlertSeverity>
+          <AlertParameters>
+            <AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
+            <AlertParameter2>$Data/Context/Property[@Name="QueueName"]$</AlertParameter2>
+            <AlertParameter3>$Data/Context/Property[@Name="QueueDepth"]$</AlertParameter3>
+            <AlertParameter4>$Data/Context/Property[@Name="QueuePercentUsed"]$</AlertParameter4>
+          </AlertParameters>
+        </AlertSettings>
+        <OperationalStates>
+          <OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
+          <OperationalState ID="Warning" MonitorTypeStateID="Warning" HealthState="Warning" />
+          <OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
+        </OperationalStates>
+        <Configuration>
+          <IntervalSeconds>901</IntervalSeconds>
+          <TimeoutSeconds>300</TimeoutSeconds>
+          <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+          <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+          <WarningThreshold>50</WarningThreshold>
+          <CriticalThreshold>75</CriticalThreshold>
+        </Configuration>
+      </UnitMonitor>
+      <UnitMonitor ID="IBM.MQ.ListenerStatus.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Listener" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.ListenerStatus.Monitor.MonitorType" ConfirmDelivery="false">
+        <Category>AvailabilityHealth</Category>
+        <AlertSettings AlertMessage="IBM.MQ.ListenerStatus.Monitor.AlertMessage">
+          <AlertOnState>Error</AlertOnState>
+          <AutoResolve>true</AutoResolve>
+          <AlertPriority>Normal</AlertPriority>
+          <AlertSeverity>MatchMonitorHealth</AlertSeverity>
+          <AlertParameters>
+            <AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
+            <AlertParameter2>$Data/Context/Property[@Name="ListenerName"]$</AlertParameter2>
+            <AlertParameter3>$Data/Context/Property[@Name="LStatus"]$</AlertParameter3>
+          </AlertParameters>
+        </AlertSettings>
+        <OperationalStates>
+          <OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
+          <OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
+        </OperationalStates>
+        <Configuration>
+          <IntervalSeconds>902</IntervalSeconds>
+          <ListenerName>$Target/Property[Type="IBM.MQ.Listener"]/ListenerName$</ListenerName>
+          <QueueManagerName>$Target/Property[Type="IBM.MQ.Listener"]/QueueManagerName$</QueueManagerName>
+          <TimeoutSeconds>300</TimeoutSeconds>
+        </Configuration>
+      </UnitMonitor>
+      <UnitMonitor ID="IBM.MQ.MQ_Installation1.Service.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Server" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="Windows!Microsoft.Windows.CheckNTServiceStateMonitorType" ConfirmDelivery="false">
+        <Category>AvailabilityHealth</Category>
+        <AlertSettings AlertMessage="IBM.MQ.MQ_Installation1.Service.Monitor.AlertMessage">
+          <AlertOnState>Error</AlertOnState>
+          <AutoResolve>true</AutoResolve>
+          <AlertPriority>High</AlertPriority>
+          <AlertSeverity>Error</AlertSeverity>
+          <AlertParameters>
+            <AlertParameter1>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/NetbiosComputerName$</AlertParameter1>
+          </AlertParameters>
+        </AlertSettings>
+        <OperationalStates>
+          <OperationalState ID="Running" MonitorTypeStateID="Running" HealthState="Success" />
+          <OperationalState ID="NotRunning" MonitorTypeStateID="NotRunning" HealthState="Error" />
+        </OperationalStates>
+        <Configuration>
+          <ComputerName />
+          <ServiceName>MQ_Installation1</ServiceName>
+          <CheckStartupType />
+        </Configuration>
+      </UnitMonitor>
+      <UnitMonitor ID="IBM.MQ.QueueIPPROCS.Monitor" Accessibility="Public" Enabled="false" Target="IBM.MQ.Queue" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueueIPPROCS.Monitor.MonitorType" ConfirmDelivery="false">
+        <Category>AvailabilityHealth</Category>
+        <AlertSettings AlertMessage="IBM.MQ.QueueIPPROCS.Monitor.AlertMessage">
+          <AlertOnState>Error</AlertOnState>
+          <AutoResolve>true</AutoResolve>
+          <AlertPriority>Normal</AlertPriority>
+          <AlertSeverity>MatchMonitorHealth</AlertSeverity>
+          <AlertParameters>
+            <AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
+            <AlertParameter2>$Data/Context/Property[@Name="QueueName"]$</AlertParameter2>
+            <AlertParameter3>$Data/Context/Property[@Name="IPPROCS"]$</AlertParameter3>
+          </AlertParameters>
+        </AlertSettings>
+        <OperationalStates>
+          <OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
+          <OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
+        </OperationalStates>
+        <Configuration>
+          <IntervalSeconds>901</IntervalSeconds>
+          <TimeoutSeconds>300</TimeoutSeconds>
+          <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+          <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+        </Configuration>
+      </UnitMonitor>
+      <UnitMonitor ID="IBM.MQ.QueueManagerStatus.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueueManagerStatus.Monitor.MonitorType" ConfirmDelivery="false">
+        <Category>AvailabilityHealth</Category>
+        <AlertSettings AlertMessage="IBM.MQ.QueueManagerStatus.Monitor.AlertMessage">
+          <AlertOnState>Error</AlertOnState>
+          <AutoResolve>true</AutoResolve>
+          <AlertPriority>Normal</AlertPriority>
+          <AlertSeverity>MatchMonitorHealth</AlertSeverity>
+          <AlertParameters>
+            <AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
+            <AlertParameter2>$Data/Context/Property[@Name="QMGRStatus"]$</AlertParameter2>
+          </AlertParameters>
+        </AlertSettings>
+        <OperationalStates>
+          <OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
+          <OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
+        </OperationalStates>
+        <Configuration>
+          <IntervalSeconds>904</IntervalSeconds>
+          <QueueManagerName>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</QueueManagerName>
+          <TimeoutSeconds>300</TimeoutSeconds>
+        </Configuration>
+      </UnitMonitor>
+      <DependencyMonitor ID="IBM.MQ.QueueManagerChannels.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.QueueManager.Hosts.Channel" MemberMonitor="Health!System.Health.AvailabilityState">
+        <Category>Custom</Category>
+        <Algorithm>WorstOf</Algorithm>
+        <MemberUnAvailable>Error</MemberUnAvailable>
+      </DependencyMonitor>
+      <DependencyMonitor ID="IBM.MQ.QueueManagerListeners.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.QueueManager.Hosts.Listener" MemberMonitor="Health!System.Health.AvailabilityState">
+        <Category>Custom</Category>
+        <Algorithm>WorstOf</Algorithm>
+        <MemberUnAvailable>Error</MemberUnAvailable>
+      </DependencyMonitor>
+      <DependencyMonitor ID="IBM.MQ.QueueManagerQueues.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.QueueManager.Hosts.Queue" MemberMonitor="Health!System.Health.AvailabilityState">
+        <Category>Custom</Category>
+        <Algorithm>WorstOf</Algorithm>
+        <MemberUnAvailable>Error</MemberUnAvailable>
+      </DependencyMonitor>
+      <DependencyMonitor ID="IBM.MQ.QueueManagerToServer.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Server" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.Server.Hosts.QueueManager" MemberMonitor="Health!System.Health.AvailabilityState">
+        <Category>Custom</Category>
+        <Algorithm>WorstOf</Algorithm>
+        <MemberUnAvailable>Error</MemberUnAvailable>
+      </DependencyMonitor>
+    </Monitors>
+  </Monitoring>
+  <Presentation>
+    <Views>
+      <View ID="IBM.MQ.Channel.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Channel" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
+        <Category>Custom</Category>
+        <Criteria />
+      </View>
+      <View ID="IBM.MQ.Listeners.Performance.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Listener" TypeID="SC!Microsoft.SystemCenter.PerformanceViewType" Visible="true">
+        <Category>Custom</Category>
+        <Criteria />
+      </View>
+      <View ID="IBM.MQ.Listener.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Listener" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
+        <Category>Custom</Category>
+        <Criteria />
+      </View>
+      <View ID="IBM.MQ.QueueManager.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.QueueManager" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
+        <Category>Custom</Category>
+        <Criteria />
+      </View>
+      <View ID="IBM.MQ.Queue.Performance.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Queue" TypeID="SC!Microsoft.SystemCenter.PerformanceViewType" Visible="true">
+        <Category>Custom</Category>
+        <Criteria />
+      </View>
+      <View ID="IBM.MQ.Queue.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Queue" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
+        <Category>Custom</Category>
+        <Criteria />
+      </View>
+      <View ID="IBM.MQ.Server.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Server" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
+        <Category>Custom</Category>
+        <Criteria />
+      </View>
+      <View ID="IBM.MQ.Server.Alert.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Server" TypeID="SC!Microsoft.SystemCenter.AlertViewType" Visible="true">
+        <Category>Custom</Category>
+        <Criteria>
+          <ResolutionState>
+            <StateRange Operator="NotEquals">255</StateRange>
+          </ResolutionState>
+        </Criteria>
+      </View>
+    </Views>
+    <Folders>
+      <Folder ID="IBM.MQ.Channel.Folder" Accessibility="Internal" ParentFolder="IBM.MQ.Root.Folder" />
+      <Folder ID="IBM.MQ.Root.Folder" Accessibility="Internal" ParentFolder="SC!Microsoft.SystemCenter.Monitoring.ViewFolder.Root" />
+      <Folder ID="IBM.MQ.Listener.Folder" Accessibility="Internal" ParentFolder="IBM.MQ.Root.Folder" />
+      <Folder ID="IBM.MQ.Queues.Folder" Accessibility="Internal" ParentFolder="IBM.MQ.Root.Folder" />
+    </Folders>
+    <FolderItems>
+      <FolderItem ElementID="IBM.MQ.Channel.State.View" ID="IBM.MQ.Channel.State.View.FolderItem" Folder="IBM.MQ.Channel.Folder" />
+      <FolderItem ElementID="IBM.MQ.Listeners.Performance.View" ID="IBM.MQ.Listeners.Performance.View.FolderItem" Folder="IBM.MQ.Listener.Folder" />
+      <FolderItem ElementID="IBM.MQ.Listener.State.View" ID="IBM.MQ.Listener.State.View.FolderItem" Folder="IBM.MQ.Listener.Folder" />
+      <FolderItem ElementID="IBM.MQ.QueueManager.State.View" ID="IBM.MQ.QueueManager.State.View.FolderItem" Folder="IBM.MQ.Root.Folder" />
+      <FolderItem ElementID="IBM.MQ.Queue.Performance.View" ID="IBM.MQ.Queue.Performance.View.FolderItem" Folder="IBM.MQ.Queues.Folder" />
+      <FolderItem ElementID="IBM.MQ.Queue.State.View" ID="IBM.MQ.Queue.State.View.FolderItem" Folder="IBM.MQ.Queues.Folder" />
+      <FolderItem ElementID="IBM.MQ.Server.State.View" ID="IBM.MQ.Server.State.View.FolderItem" Folder="IBM.MQ.Root.Folder" />
+      <FolderItem ElementID="IBM.MQ.Server.Alert.View" ID="IBM.MQ.Server.Alert.View.FolderItem" Folder="IBM.MQ.Root.Folder" />
+    </FolderItems>
+    <StringResources>
+      <StringResource ID="IBM.MQ.ChannelStatus.Monitor.AlertMessage" />
+      <StringResource ID="IBM.MQ.ListenerStatus.Monitor.AlertMessage" />
+      <StringResource ID="IBM.MQ.MQ_Installation1.Service.Monitor.AlertMessage" />
+      <StringResource ID="IBM.MQ.QueueManagerStatus.Monitor.AlertMessage" />
+      <StringResource ID="IBM.MQ.QueueDepth.Monitor.AlertMessage" />
+      <StringResource ID="IBM.MQ.QueuePercentUsed.Monitor.AlertMessage" />
+      <StringResource ID="IBM.MQ.QueueIPPROCS.Monitor.AlertMessage" />
+    </StringResources>
+  </Presentation>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="IBM.MQ">
+          <Name>IBM MQ</Name>
+          <Description>IBM WebSphere MQ Management Pack</Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Channel">
+          <Name>Channel</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Channel.Discovery">
+          <Name>IBM MQ Channel Discovery</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Channel.Folder">
+          <Name>Channels</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Channel.State.View">
+          <Name>Channel State</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Channel" SubElementID="ChannelName">
+          <Name>Channel Name</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Channel" SubElementID="ChannelType">
+          <Name>Channel Type</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Channel" SubElementID="QueueManagerName">
+          <Name>Queue Manager Name</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor">
+          <Name>IBM MQ Channel Status Monitor</Name>
+          <Description></Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor.AlertMessage">
+          <Name>IBM MQ Channel Status Alert</Name>
+          <Description>IBM MQ Channel Status is not Running.
 Channel Status: {2}
 Channel Name: {1}
 Queue Manager Name: {0}</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor" SubElementID="Error">
-					<Name>Not Running</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor" SubElementID="Success">
-					<Name>Running or Inactive</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueDepth.Monitor">
-					<Name>IBM MQ Queue Depth Monitor</Name>
-					<Description></Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueDepth.Monitor.AlertMessage">
-					<Name>IBM MQ Queue Depth exceeds threshold</Name>
-					<Description>The current queue depth is above the threshold.
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor" SubElementID="Error">
+          <Name>Not Running</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor" SubElementID="Success">
+          <Name>Running or Inactive</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueDepth.Monitor">
+          <Name>IBM MQ Queue Depth Monitor</Name>
+          <Description></Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueDepth.Monitor.AlertMessage">
+          <Name>IBM MQ Queue Depth exceeds threshold</Name>
+          <Description>The current queue depth is above the threshold.
 Queue Depth: {2}
 Queue Name: {1}
 Queue Manager Name {0}</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueDepth.Monitor" SubElementID="Error">
-					<Name>Error</Name>
-					<Description>Error</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueDepth.Monitor" SubElementID="Success">
-					<Name>Success</Name>
-					<Description>Success</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueDepth.Monitor" SubElementID="Warning">
-					<Name>Warning</Name>
-					<Description>Warning</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueDepth.PerformanceCollection.Rule">
-					<Name>IBM MQ CurrentQueueDepth Performance Collection Rule</Name>
-					<Description></Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor">
-					<Name>IBM MQ Queue Percent Used Monitor</Name>
-					<Description></Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor.AlertMessage">
-					<Name>IBM MQ Queue Percent Used exceeds threshold</Name>
-					<Description>The current queue percent used is above the threshold.
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueDepth.Monitor" SubElementID="Error">
+          <Name>Error</Name>
+          <Description>Error</Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueDepth.Monitor" SubElementID="Success">
+          <Name>Success</Name>
+          <Description>Success</Description>
+        </DisplayString>
+       <DisplayString ElementID="IBM.MQ.QueueDepth.Monitor" SubElementID="Warning">
+          <Name>Warning</Name>
+          <Description>Warning</Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueDepth.PerformanceCollection.Rule">
+          <Name>IBM MQ CurrentQueueDepth Performance Collection Rule</Name>
+          <Description></Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor">
+          <Name>IBM MQ Queue Percent Used Monitor</Name>
+          <Description></Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor.AlertMessage">
+          <Name>IBM MQ Queue Percent Used exceeds threshold</Name>
+          <Description>The current queue percent used is above the threshold.
 Queue Percent Used: {3}
 Queue Depth: {2}
 Queue Name: {1}
 Queue Manager Name {0}</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor" SubElementID="Error">
-					<Name>Error</Name>
-					<Description>Error</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor" SubElementID="Success">
-					<Name>Success</Name>
-					<Description>Success</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor" SubElementID="Warning">
-					<Name>Warning</Name>
-					<Description>Warning</Description>
-				</DisplayString>				
-				<DisplayString ElementID="IBM.MQ.QueuePercentUsed.PerformanceCollection.Rule">
-					<Name>IBM MQ Queue Percent Used Performance Collection Rule</Name>
-					<Description></Description>
-				</DisplayString>				
-				<DisplayString ElementID="IBM.MQ.Listener">
-					<Name>Listener</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Listener.Discovery">
-					<Name>IBM MQ Listener Discovery</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Listener.Folder">
-					<Name>Listeners</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Listener.State.View">
-					<Name>Listener State</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Listener" SubElementID="ListenerName">
-					<Name>Listener Name</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Listener" SubElementID="QueueManagerName">
-					<Name>Queue Manager Name</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Listeners.Performance.View">
-					<Name>Listener Performance</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.ListenerSessions.PerformanceCollection.Rule">
-					<Name>IBM MQ Listener Sessions Performance Collection Rule</Name>
-					<Description>Collect number of sessions on Listener</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor">
-					<Name>IBM MQ Listener Status Monitor</Name>
-					<Description></Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor.AlertMessage">
-					<Name>IBM MQ Listener Status is Not Running</Name>
-					<Description>IBM MQ Listener Status is not Running.
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor" SubElementID="Error">
+          <Name>Error</Name>
+          <Description>Error</Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor" SubElementID="Success">
+          <Name>Success</Name>
+          <Description>Success</Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor" SubElementID="Warning">
+          <Name>Warning</Name>
+          <Description>Warning</Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueuePercentUsed.PerformanceCollection.Rule">
+          <Name>IBM MQ Queue Percent Used Performance Collection Rule</Name>
+          <Description></Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Listener">
+          <Name>Listener</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Listener.Discovery">
+          <Name>IBM MQ Listener Discovery</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Listener.Folder">
+          <Name>Listeners</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Listener.State.View">
+          <Name>Listener State</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Listener" SubElementID="ListenerName">
+          <Name>Listener Name</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Listener" SubElementID="QueueManagerName">
+          <Name>Queue Manager Name</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Listeners.Performance.View">
+          <Name>Listener Performance</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.ListenerSessions.PerformanceCollection.Rule">
+          <Name>IBM MQ Listener Sessions Performance Collection Rule</Name>
+          <Description>Collect number of sessions on Listener</Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor">
+          <Name>IBM MQ Listener Status Monitor</Name>
+          <Description></Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor.AlertMessage">
+          <Name>IBM MQ Listener Status is Not Running</Name>
+          <Description>IBM MQ Listener Status is not Running.
 Listener Status: {2}
 Listener Name: {1}
 Queue Manager Name: {0}</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor" SubElementID="Error">
-					<Name>Not Running</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor" SubElementID="Success">
-					<Name>Running</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor">
-					<Name>IBM MQ MQ_Installation1 Service Monitor</Name>
-					<Description></Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor.AlertMessage">
-					<Name>IBM MQ MQ_Installation1 Service is not running</Name>
-					<Description>IBM WebSphere MQ (Installation1) Service Not running on server {0}.</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor" SubElementID="NotRunning">
-					<Name>NotRunning</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor" SubElementID="Running">
-					<Name>Running</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Server.Alert.View">
-					<Name>Alerts</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Queue">
-					<Name>Queue</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Queue.Discovery">
-					<Name>IBM MQ Queue Discovery</Name>
-					<Description></Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor">
-					<Name>IBM MQ Queue IPPROCS Monitor</Name>
-					<Description></Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor" SubElementID="Error">
-					<Name>Error</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor" SubElementID="Success">
-					<Name>Success</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor.AlertMessage">
-					<Name>IBM MQ IPPROCS Monitor greater than zero</Name>
-					<Description>The current IPPROCS value is above the threshold.
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor" SubElementID="Error">
+          <Name>Not Running</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor" SubElementID="Success">
+          <Name>Running</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor">
+          <Name>IBM MQ MQ_Installation1 Service Monitor</Name>
+          <Description></Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor.AlertMessage">
+          <Name>IBM MQ MQ_Installation1 Service is not running</Name>
+          <Description>IBM WebSphere MQ (Installation1) Service Not running on server {0}.</Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor" SubElementID="NotRunning">
+          <Name>NotRunning</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor" SubElementID="Running">
+          <Name>Running</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Server.Alert.View">
+          <Name>Alerts</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Queue">
+          <Name>Queue</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Queue.Discovery">
+          <Name>IBM MQ Queue Discovery</Name>
+          <Description></Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor">
+          <Name>IBM MQ Queue IPPROCS Monitor</Name>
+          <Description></Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor" SubElementID="Error">
+          <Name>Error</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor" SubElementID="Success">
+          <Name>Success</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor.AlertMessage">
+          <Name>IBM MQ IPPROCS Monitor greater than zero</Name>
+          <Description>The current IPPROCS value is above the threshold.
 IPPROCS value: {2}
 Queue Name: {1}
 Queue Manager Name {0}</Description>
-                </DisplayString>			
-				<DisplayString ElementID="IBM.MQ.Queue.Performance.View">
-					<Name>Queue Performance</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Queue.State.View">
-					<Name>Queue State</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Queue" SubElementID="DESCR">
-					<Name>Description</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueIPPROCS.PerformanceCollection.Rule">
-					<Name>IBM MQ QueueIPPROCS Performance Collection Rule</Name>
-					<Description>Number of Applications reading from this queue</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueManager">
-					<Name>Queue Manager</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueManager.Discovery">
-					<Name>IBM MQ QueueManager Discovery</Name>
-					<Description></Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueManager.State.View">
-					<Name>Queue Managers</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueManagerChannels.DependencyRollup.Monitor">
-					<Name>IBM MQ Channels To QueueManager Dependency Rollup Monitor</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueManagerListeners.DependencyRollup.Monitor">
-					<Name>IBM MQ Listeners To QueueManager Dependency Rollup Monitor</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueManager" SubElementID="QueueManagerName">
-					<Name>Queue Manager Name</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueManagerQueues.DependencyRollup.Monitor">
-					<Name>IBM MQ Queues To QueueManager Dependency Rollup Monitor"</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor">
-					<Name>IBM MQ QueueManager Status Monitor</Name>
-					<Description></Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor.AlertMessage">
-					<Name>IBM Queue Manager Status is Not Running</Name>
-					<Description>IBM Queue Manager Status is not Running.
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Queue.Performance.View">
+          <Name>Queue Performance</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Queue.State.View">
+          <Name>Queue State</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Queue" SubElementID="DESCR">
+          <Name>Description</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueIPPROCS.PerformanceCollection.Rule">
+          <Name>IBM MQ QueueIPPROCS Performance Collection Rule</Name>
+          <Description>Number of Applications reading from this queue</Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueManager">
+          <Name>Queue Manager</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueManager.Discovery">
+          <Name>IBM MQ QueueManager Discovery</Name>
+          <Description></Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueManager.State.View">
+          <Name>Queue Managers</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueManagerChannels.DependencyRollup.Monitor">
+          <Name>IBM MQ Channels To QueueManager Dependency Rollup Monitor</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueManagerListeners.DependencyRollup.Monitor">
+          <Name>IBM MQ Listeners To QueueManager Dependency Rollup Monitor</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueManager" SubElementID="QueueManagerName">
+          <Name>Queue Manager Name</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueManagerQueues.DependencyRollup.Monitor">
+          <Name>IBM MQ Queues To QueueManager Dependency Rollup Monitor"</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor">
+          <Name>IBM MQ QueueManager Status Monitor</Name>
+          <Description></Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor.AlertMessage">
+          <Name>IBM Queue Manager Status is Not Running</Name>
+          <Description>IBM Queue Manager Status is not Running.
 
 Status: {0}
 Queue Manager Name: {1}
 Host Name: {2}</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor" SubElementID="Error">
-					<Name>Error</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor" SubElementID="Success">
-					<Name>Success</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueManagerToServer.DependencyRollup.Monitor">
-					<Name>IBM MQ QueueManager To Server DependencyRollup Monitor</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Queue" SubElementID="MAXDEPTH">
-					<Name>MAXDEPTH</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Queue" SubElementID="MAXMSGL">
-					<Name>MAXMSGL</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.QueueOPPROCS.PerformanceCollection.Rule">
-					<Name>IBM MQ QueueOPPROCS Performance Collection Rule</Name>
-					<Description>Number of Applications writing on this queue</Description>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Queue" SubElementID="QueueManagerName">
-					<Name>Queue Manager Name</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Queue" SubElementID="QueueName">
-					<Name>Queue Name</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Queues.Folder">
-					<Name>Queues</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Queue" SubElementID="TYPE">
-					<Name>TYPE</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Root.Folder">
-					<Name>IBM MQ</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Server">
-					<Name>IBM MQ Server</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Server" SubElementID="Version">
-					<Name>Version</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Server" SubElementID="InstallPath">
-					<Name>InstallPath</Name>
-				</DisplayString>				
-				<DisplayString ElementID="IBM.MQ.Server.Discovery">
-					<Name>IBM MQ Server Discovery</Name>
-				</DisplayString>
-				<DisplayString ElementID="IBM.MQ.Server.State.View">
-					<Name>MQ Server State</Name>
-				</DisplayString>
-			</DisplayStrings>
-		</LanguagePack>
-	</LanguagePacks>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor" SubElementID="Error">
+          <Name>Error</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor" SubElementID="Success">
+          <Name>Success</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueManagerToServer.DependencyRollup.Monitor">
+          <Name>IBM MQ QueueManager To Server DependencyRollup Monitor</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Queue" SubElementID="MAXDEPTH">
+          <Name>MAXDEPTH</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Queue" SubElementID="MAXMSGL">
+          <Name>MAXMSGL</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.QueueOPPROCS.PerformanceCollection.Rule">
+          <Name>IBM MQ QueueOPPROCS Performance Collection Rule</Name>
+          <Description>Number of Applications writing on this queue</Description>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Queue" SubElementID="QueueManagerName">
+          <Name>Queue Manager Name</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Queue" SubElementID="QueueName">
+          <Name>Queue Name</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Queues.Folder">
+          <Name>Queues</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Queue" SubElementID="TYPE">
+          <Name>TYPE</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Root.Folder">
+          <Name>IBM MQ</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Server">
+          <Name>IBM MQ Server</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Server" SubElementID="Version">
+          <Name>Version</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Server" SubElementID="InstallPath">
+          <Name>InstallPath</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Server.Discovery">
+          <Name>IBM MQ Server Discovery</Name>
+        </DisplayString>
+        <DisplayString ElementID="IBM.MQ.Server.State.View">
+          <Name>MQ Server State</Name>
+        </DisplayString>
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
 </ManagementPack>

--- a/IBM.MQ.xml
+++ b/IBM.MQ.xml
@@ -3,7 +3,7 @@
 	<Manifest>
 		<Identity>
 			<ID>IBM.MQ</ID>
-			<Version>3.2.1.8</Version>
+			<Version>3.2.1.9</Version>
 		</Identity>
 		<Name>IBM.MQ</Name>
 		<References>
@@ -1928,7 +1928,7 @@ param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName
 # ScriptName should be the same as the ID of the module that the script is contained in
 $ScriptName = "IBM.MQ.Queue.Discovery.ps1"
 $EventID = "7104"
-[bool]$DiscoverSystemQueues = $true
+[bool]$DiscoverSystemQueues = $false
 #=================================================================================
 
 

--- a/IBM.MQ.xml
+++ b/IBM.MQ.xml
@@ -3,7 +3,7 @@
 	<Manifest>
 		<Identity>
 			<ID>IBM.MQ</ID>
-			<Version>3.2.1.7</Version>
+			<Version>3.2.1.8</Version>
 		</Identity>
 		<Name>IBM.MQ</Name>
 		<References>
@@ -222,88 +222,88 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
   $Qout = Invoke-Expression $Qcmd
   FOREACH ($QLine in $Qout)
   {
-    $Qmatch = $QLine | Select-String -Pattern 'QUEUE\('
-    IF ($Qmatch)
-    {
-      $QLineSplit = $QLine.Split("(,)")
-      [string]$QueueName = $QLineSplit[1]
-      # Write-Host "Found Queue: ($QueueName)"
+	$Qmatch = $QLine | Select-String -Pattern 'QUEUE\('
+	IF ($Qmatch)
+	{
+	  $QLineSplit = $QLine.Split("(,)")
+	  [string]$QueueName = $QLineSplit[1]
+	  # Write-Host "Found Queue: ($QueueName)"
 
-      #Get the Queue Properties from the Queue      
-      $QPropsCmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display Queue($QueueName) | runmqsc $QueueManagerName'"
-      $QPropsOut = Invoke-Expression $QPropsCmd
-      # Loop through each line of the Queue properties and pull out any interesting data for a propertybag
-      FOREACH ($QPropLine in $QPropsOut)
-      {
-        #Get QueueDepth
-        $QDmatch = $QPropLine | Select-String -Pattern 'CURDEPTH\('
-        IF ($QDMatch)
-        {
-          $Splitter = "CURDEPTH"
-          $QDLineSplit = $QDMatch -Split $Splitter
-          $QD = $QDLineSplit[1]
-          $QD = $QD.Substring(0, $QD.IndexOf(')'))
-          $QD = $QD -Replace "[()]",""
-          $QD = $QD.Trim()
+	  #Get the Queue Properties from the Queue      
+	  $QPropsCmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display Queue($QueueName) | runmqsc $QueueManagerName'"
+	  $QPropsOut = Invoke-Expression $QPropsCmd
+	  # Loop through each line of the Queue properties and pull out any interesting data for a propertybag
+	  FOREACH ($QPropLine in $QPropsOut)
+	  {
+		#Get QueueDepth
+		$QDmatch = $QPropLine | Select-String -Pattern 'CURDEPTH\('
+		IF ($QDMatch)
+		{
+		  $Splitter = "CURDEPTH"
+		  $QDLineSplit = $QDMatch -Split $Splitter
+		  $QD = $QDLineSplit[1]
+		  $QD = $QD.Substring(0, $QD.IndexOf(')'))
+		  $QD = $QD -Replace "[()]",""
+		  $QD = $QD.Trim()
 		  [int]$QueueDepth = $QD
-          #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) QueueDepth:($QueueDepth)"
+		  #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) QueueDepth:($QueueDepth)"
 		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nQueueDepth:($QueueDepth).")
-        }
+		}
 
-        #Get IPPROCS
-        $QIPPROCSmatch = $QPropLine | Select-String -Pattern 'IPPROCS\('
-        IF ($QIPPROCSmatch)
-        {
-          $Splitter = "IPPROCS"
-          $QIPPROCSSplit = $QIPPROCSmatch -Split $Splitter
-          $QIPPROCS = $QIPPROCSSplit[1]
-          $QIPPROCS = $QIPPROCS.Substring(0, $QIPPROCS.IndexOf(')'))
-          $QIPPROCS = $QIPPROCS -Replace "[()]",""
-          $QIPPROCS = $QIPPROCS.Trim()
+		#Get IPPROCS
+		$QIPPROCSmatch = $QPropLine | Select-String -Pattern 'IPPROCS\('
+		IF ($QIPPROCSmatch)
+		{
+		  $Splitter = "IPPROCS"
+		  $QIPPROCSSplit = $QIPPROCSmatch -Split $Splitter
+		  $QIPPROCS = $QIPPROCSSplit[1]
+		  $QIPPROCS = $QIPPROCS.Substring(0, $QIPPROCS.IndexOf(')'))
+		  $QIPPROCS = $QIPPROCS -Replace "[()]",""
+		  $QIPPROCS = $QIPPROCS.Trim()
 		  [int]$IPPROCS = $QIPPROCS
-          #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) IPPROCS:($IPPROCS)"
+		  #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) IPPROCS:($IPPROCS)"
 		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nIPPROCS:($IPPROCS).")
-        }
+		}
 
-        #Get OPPROCS
-        $QOPPROCSmatch = $QPropLine | Select-String -Pattern 'OPPROCS\('
-        IF ($QOPPROCSmatch)
-        {
-          $Splitter = "OPPROCS"
-          $QOPPROCSSplit = $QOPPROCSmatch -Split $Splitter
-          $QOPPROCS = $QOPPROCSSplit[1]
-          $QOPPROCS = $QOPPROCS.Substring(0, $QOPPROCS.IndexOf(')'))
-          $QOPPROCS = $QOPPROCS -Replace "[()]",""
-          $QOPPROCS = $QOPPROCS.Trim()
+		#Get OPPROCS
+		$QOPPROCSmatch = $QPropLine | Select-String -Pattern 'OPPROCS\('
+		IF ($QOPPROCSmatch)
+		{
+		  $Splitter = "OPPROCS"
+		  $QOPPROCSSplit = $QOPPROCSmatch -Split $Splitter
+		  $QOPPROCS = $QOPPROCSSplit[1]
+		  $QOPPROCS = $QOPPROCS.Substring(0, $QOPPROCS.IndexOf(')'))
+		  $QOPPROCS = $QOPPROCS -Replace "[()]",""
+		  $QOPPROCS = $QOPPROCS.Trim()
 		  [int]$OPPROCS = $QOPPROCS
-          #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) OPPROCS:($OPPROCS)"
+		  #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) OPPROCS:($OPPROCS)"
 		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nOPPROCS:($OPPROCS).")
-        }
+		}
 
-        #Get Queue MAXDEPTH
-        $QMAXDEPTHmatch = $QPropLine | Select-String -Pattern 'MAXDEPTH\('
-        IF ($QMAXDEPTHmatch)
-        {
-          $Splitter = "MAXDEPTH"
-          $QMAXDEPTHSplit = $QMAXDEPTHmatch -Split $Splitter
-          $QMAXDEPTH = $QMAXDEPTHSplit[1]
-          $QMAXDEPTH = $QMAXDEPTH.Substring(0, $QMAXDEPTH.IndexOf(')'))
-          $QMAXDEPTH = $QMAXDEPTH -Replace "[()]",""
-          $QMAXDEPTH = $QMAXDEPTH.Trim()
+		#Get Queue MAXDEPTH
+		$QMAXDEPTHmatch = $QPropLine | Select-String -Pattern 'MAXDEPTH\('
+		IF ($QMAXDEPTHmatch)
+		{
+		  $Splitter = "MAXDEPTH"
+		  $QMAXDEPTHSplit = $QMAXDEPTHmatch -Split $Splitter
+		  $QMAXDEPTH = $QMAXDEPTHSplit[1]
+		  $QMAXDEPTH = $QMAXDEPTH.Substring(0, $QMAXDEPTH.IndexOf(')'))
+		  $QMAXDEPTH = $QMAXDEPTH -Replace "[()]",""
+		  $QMAXDEPTH = $QMAXDEPTH.Trim()
 		  [int]$MAXDEPTH = $QMAXDEPTH
-          #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) MAXDEPTH:($MAXDEPTH)"
+		  #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) MAXDEPTH:($MAXDEPTH)"
 		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nMAXDEPTH:($MAXDEPTH).")
-        }
-      }
+		}
+	  }
 
-      #Get Queue Percent Used
-      [int]$QueuePercentUsed = ([Math]::Round(($QueueDepth / $MAXDEPTH),2)*100)
-      #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) QueuePercentUsed:($QueuePercentUsed)"
+	  #Get Queue Percent Used
+	  [int]$QueuePercentUsed = ([Math]::Round(($QueueDepth / $MAXDEPTH),2)*100)
+	  #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) QueuePercentUsed:($QueuePercentUsed)"
 
-      # Load PropertyBag function 
-      $bag = $momapi.CreatePropertyBag()
-      #Create PropertyBags
-      $bag.AddValue('QueueManagerName',$QueueManagerName)
+	  # Load PropertyBag function 
+	  $bag = $momapi.CreatePropertyBag()
+	  #Create PropertyBags
+	  $bag.AddValue('QueueManagerName',$QueueManagerName)
 	  $bag.AddValue('QueueName',$QueueName)
 	  $bag.AddValue('QueueDepth',$QueueDepth)
 	  $bag.AddValue('MAXDEPTH',$MAXDEPTH)
@@ -312,7 +312,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
 	  $bag.AddValue('OPPROCS',$OPPROCS)
 	  #Return each property bag as we create and populate it.
 	  $bag
-    }
+	}
   }
 }
 #=================================================================================
@@ -1680,35 +1680,38 @@ Set-WinUILanguageOverride -Language "en-US"
 $Ccmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display channel(*) | runmqsc $QueueManagerName'"
 $Cout = Invoke-Expression "$Ccmd"
 
-FOREACH ($CLine in $Cout)
+IF ($Cout -notlike "*IBM MQ queue manager not available.*")
 {
-  $Cmatch = $CLine | Select-String -Pattern 'CHANNEL\(' -CaseSensitive
-  IF ($Cmatch)
-  {
-    $CLineSplit = $CLine.Split("(,)")
-    [string]$ChannelName = $CLineSplit[1]
-    $ChannelName = $ChannelName.Trim()
-    [string]$ChannelType = $CLineSplit[3]
-    $ChannelType = $ChannelType.Trim()
-    #Write-Host "Found Channel Name: ($ChannelName) Type:($ChannelType)"
-  
-    $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nDiscovering Channel: ($ChannelName). `nChannel Type:($ChannelType). `nQueue Manager: ($QueueManagerName).")
+	FOREACH ($CLine in $Cout)
+	{
+	  $Cmatch = $CLine | Select-String -Pattern 'CHANNEL\(' -CaseSensitive
+	  IF ($Cmatch)
+	  {
+		$CLineSplit = $CLine.Split("(,)")
+		[string]$ChannelName = $CLineSplit[1]
+		$ChannelName = $ChannelName.Trim()
+		[string]$ChannelType = $CLineSplit[3]
+		$ChannelType = $ChannelType.Trim()
+		#Write-Host "Found Channel Name: ($ChannelName) Type:($ChannelType)"
+	  
+		$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nDiscovering Channel: ($ChannelName). `nChannel Type:($ChannelType). `nQueue Manager: ($QueueManagerName).")
 
-    $instance = $DiscoveryData.CreateClassInstance("$MPElement[Name='IBM.MQ.Channel']$")
-    $instance.AddProperty("$MPElement[Name='Windows!Microsoft.Windows.Computer']/PrincipalName$",$ComputerName)
-    $instance.AddProperty("$MPElement[Name='IBM.MQ.QueueManager']/QueueManagerName$",$QueueManagerName)
-    $instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/ChannelName$",$ChannelName)
-    $instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/ChannelType$",$ChannelType)
-    $instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/QueueManagerName$",$QueueManagerName)	
-    $instance.AddProperty("$MPElement[Name='System!System.Entity']/DisplayName$", $ChannelName)
-    $DiscoveryData.AddInstance($instance)
-  }
+		$instance = $DiscoveryData.CreateClassInstance("$MPElement[Name='IBM.MQ.Channel']$")
+		$instance.AddProperty("$MPElement[Name='Windows!Microsoft.Windows.Computer']/PrincipalName$",$ComputerName)
+		$instance.AddProperty("$MPElement[Name='IBM.MQ.QueueManager']/QueueManagerName$",$QueueManagerName)
+		$instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/ChannelName$",$ChannelName)
+		$instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/ChannelType$",$ChannelType)
+		$instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/QueueManagerName$",$QueueManagerName)	
+		$instance.AddProperty("$MPElement[Name='System!System.Entity']/DisplayName$", $ChannelName)
+		$DiscoveryData.AddInstance($instance)
+	  }
+	}
+
+	# Return Discovery Items Normally           
+	$DiscoveryData
+	# Return Discovery Bag to the command line for testing (does not work from ISE)
+	# $momapi.Return($DiscoveryData)
 }
-
-# Return Discovery Items Normally           
-$DiscoveryData
-# Return Discovery Bag to the command line for testing (does not work from ISE)
-# $momapi.Return($DiscoveryData)
 #=================================================================================
 # End MAIN script section
 Set-WinUILanguageOverride
@@ -1815,32 +1818,35 @@ Set-WinUILanguageOverride -Language "en-US"
 $Lcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display listener(*) | runmqsc $QueueManagerName'"
 $Lout = Invoke-Expression "$Lcmd"
 
-FOREACH ($LLine in $Lout)
+IF ($Lout -notlike "*IBM MQ queue manager not available.*")
 {
-  $Lmatch = $LLine | Select-String -Pattern 'LISTENER\(' -CaseSensitive
-  IF ($Lmatch)
+  FOREACH ($LLine in $Lout)
   {
-    $LLineSplit = $LLine.Split("(,)")
-    [string]$ListenerName = $LLineSplit[1]
+	  $Lmatch = $LLine | Select-String -Pattern 'LISTENER\(' -CaseSensitive
+	  IF ($Lmatch)
+	  {
+		$LLineSplit = $LLine.Split("(,)")
+		[string]$ListenerName = $LLineSplit[1]
 
-    #Write-Host "Found Listener: ($ListenerName)"
-  
-    $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nDiscovering Listener: ($ListenerName) `nQueue Manager: ($QueueManagerName).")
+		#Write-Host "Found Listener: ($ListenerName)"
+	  
+		$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nDiscovering Listener: ($ListenerName) `nQueue Manager: ($QueueManagerName).")
 
-    $instance = $DiscoveryData.CreateClassInstance("$MPElement[Name='IBM.MQ.Listener']$")
-    $instance.AddProperty("$MPElement[Name='Windows!Microsoft.Windows.Computer']/PrincipalName$",$ComputerName)
-    $instance.AddProperty("$MPElement[Name='IBM.MQ.QueueManager']/QueueManagerName$",$QueueManagerName)
-    $instance.AddProperty("$MPElement[Name='IBM.MQ.Listener']/ListenerName$",$ListenerName)
-    $instance.AddProperty("$MPElement[Name='IBM.MQ.Listener']/QueueManagerName$",$QueueManagerName)	
-    $instance.AddProperty("$MPElement[Name='System!System.Entity']/DisplayName$",$ListenerName)
-    $DiscoveryData.AddInstance($instance)
+		$instance = $DiscoveryData.CreateClassInstance("$MPElement[Name='IBM.MQ.Listener']$")
+		$instance.AddProperty("$MPElement[Name='Windows!Microsoft.Windows.Computer']/PrincipalName$",$ComputerName)
+		$instance.AddProperty("$MPElement[Name='IBM.MQ.QueueManager']/QueueManagerName$",$QueueManagerName)
+		$instance.AddProperty("$MPElement[Name='IBM.MQ.Listener']/ListenerName$",$ListenerName)
+		$instance.AddProperty("$MPElement[Name='IBM.MQ.Listener']/QueueManagerName$",$QueueManagerName)	
+		$instance.AddProperty("$MPElement[Name='System!System.Entity']/DisplayName$",$ListenerName)
+		$DiscoveryData.AddInstance($instance)
+	  }
   }
-}
 
-# Return Discovery Items Normally           
-$DiscoveryData
-# Return Discovery Bag to the command line for testing (does not work from ISE)
-# $momapi.Return($DiscoveryData)
+	# Return Discovery Items Normally           
+	$DiscoveryData
+	# Return Discovery Bag to the command line for testing (does not work from ISE)
+	# $momapi.Return($DiscoveryData)
+}
 #=================================================================================
 # End MAIN script section
 Set-WinUILanguageOverride
@@ -1954,111 +1960,114 @@ Set-WinUILanguageOverride -Language "en-US"
   # Write-Host "Getting Queues from ($QueueManagerName) using $Qcmd"
   $Qout = Invoke-Expression $Qcmd
   
-  FOREACH ($QLine in $Qout)
+  IF ($Qout -notlike "*IBM MQ queue manager not available.*")
   {
-    $Qmatch = $QLine | Select-String -Pattern 'QUEUE\('
-    IF ($Qmatch)
-    {
-      $QLineSplit = $QLine.Split("(,)")
-      [string]$QueueName = $QLineSplit[1]
-      #Write-Host "Found Queue: ($QueueName)"
+	  FOREACH ($QLine in $Qout)
+	  {
+		$Qmatch = $QLine | Select-String -Pattern 'QUEUE\('
+		IF ($Qmatch)
+		{
+		  $QLineSplit = $QLine.Split("(,)")
+		  [string]$QueueName = $QLineSplit[1]
+		  #Write-Host "Found Queue: ($QueueName)"
 
-      IF ($QueueName -match "SYSTEM.")
-      {
-        #This is a system queue.  Only continue if System Queues should be discovered
-        IF ($DiscoverSystemQueues)
-        {$ContinueDiscovery = $true}
-        ELSE
-        {$ContinueDiscovery = $false}
-      }
-      ELSE
-      {
-        #This is not a system queue.  Continue discovery
-        $ContinueDiscovery = $true
-      }
+		  IF ($QueueName -match "SYSTEM.")
+		  {
+			#This is a system queue.  Only continue if System Queues should be discovered
+			IF ($DiscoverSystemQueues)
+			{$ContinueDiscovery = $true}
+			ELSE
+			{$ContinueDiscovery = $false}
+		  }
+		  ELSE
+		  {
+			#This is not a system queue.  Continue discovery
+			$ContinueDiscovery = $true
+		  }
 
-      IF ($ContinueDiscovery)
-      {
-        #Get Queue Properties
-        $QPropcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display Queue ($QueueName) TYPE DESCR MAXDEPTH MAXMSGL | runmqsc $QueueManagerName'"
-        $QPropout = Invoke-Expression $QPropcmd
+		  IF ($ContinueDiscovery)
+		  {
+			#Get Queue Properties
+			$QPropcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display Queue ($QueueName) TYPE DESCR MAXDEPTH MAXMSGL | runmqsc $QueueManagerName'"
+			$QPropout = Invoke-Expression $QPropcmd
 
-        FOREACH ($QPropLine in $QPropout)
-        {
-          $QPropMatch = $QPropLine | Select-String -Pattern 'TYPE\('
-          IF ($QPropMatch)
-          {
-            $Splitter = "TYPE"
-            $QPropLine1 = $QPropLine
-            $QPropLineSplit1 = $QPropLine1 -Split $Splitter
-            $TYPE = $QPropLineSplit1[1]
-            $TYPE = ($TYPE.Split(")"))[0]
-            $TYPE = $TYPE -Replace "[(]",""
-            $TYPE = $TYPE.Trim()
-            #Write-Host "$TYPE"         
-          }
+			FOREACH ($QPropLine in $QPropout)
+			{
+			  $QPropMatch = $QPropLine | Select-String -Pattern 'TYPE\('
+			  IF ($QPropMatch)
+			  {
+				$Splitter = "TYPE"
+				$QPropLine1 = $QPropLine
+				$QPropLineSplit1 = $QPropLine1 -Split $Splitter
+				$TYPE = $QPropLineSplit1[1]
+				$TYPE = ($TYPE.Split(")"))[0]
+				$TYPE = $TYPE -Replace "[(]",""
+				$TYPE = $TYPE.Trim()
+				#Write-Host "$TYPE"         
+			  }
 
-          $QPropMatch2 = $QPropLine | Select-String -Pattern 'DESCR\('
-          IF ($QPropMatch2)
-          {
-            $QPropLine2 = $QPropLine
-            $Splitter = "DESCR"
-            $QPropLineSplit2 = $QPropLine2 -Split $Splitter
-            $DESCR = $QPropLineSplit2[1]
-            $DESCR = ($DESCR.Split(")"))[0]
-            $DESCR = $DESCR -Replace "[(]",""
-            $DESCR = $DESCR.Trim()
-            #Write-Host "$DESCR"         
-          }
+			  $QPropMatch2 = $QPropLine | Select-String -Pattern 'DESCR\('
+			  IF ($QPropMatch2)
+			  {
+				$QPropLine2 = $QPropLine
+				$Splitter = "DESCR"
+				$QPropLineSplit2 = $QPropLine2 -Split $Splitter
+				$DESCR = $QPropLineSplit2[1]
+				$DESCR = ($DESCR.Split(")"))[0]
+				$DESCR = $DESCR -Replace "[(]",""
+				$DESCR = $DESCR.Trim()
+				#Write-Host "$DESCR"         
+			  }
 
-          $QPropMatch3 = $QPropLine | Select-String -Pattern 'MAXDEPTH\('
-          IF ($QPropMatch3)
-          {
-            $QPropLine3 = $QPropLine
-            $Splitter = "MAXDEPTH"
-            $QPropLineSplit3 = $QPropLine3 -Split $Splitter
-            $MAXDEPTH = $QPropLineSplit3[1]
-            $MAXDEPTH = ($MAXDEPTH.Split(")"))[0]
-            $MAXDEPTH = $MAXDEPTH -Replace "[(]",""
-            $MAXDEPTH = $MAXDEPTH.Trim()
-            #Write-Host "$MAXDEPTH"         
-          }
+			  $QPropMatch3 = $QPropLine | Select-String -Pattern 'MAXDEPTH\('
+			  IF ($QPropMatch3)
+			  {
+				$QPropLine3 = $QPropLine
+				$Splitter = "MAXDEPTH"
+				$QPropLineSplit3 = $QPropLine3 -Split $Splitter
+				$MAXDEPTH = $QPropLineSplit3[1]
+				$MAXDEPTH = ($MAXDEPTH.Split(")"))[0]
+				$MAXDEPTH = $MAXDEPTH -Replace "[(]",""
+				$MAXDEPTH = $MAXDEPTH.Trim()
+				#Write-Host "$MAXDEPTH"         
+			  }
 
-          $QPropMatch4 = $QPropLine | Select-String -Pattern 'MAXMSGL\('
-          IF ($QPropMatch4)
-          {
-            $QPropLine4 = $QPropLine
-            $Splitter = "MAXMSGL"
-            $QPropLineSplit4 = $QPropLine4 -Split $Splitter
-            $MAXMSGL = $QPropLineSplit4[1]
-            $MAXMSGL = ($MAXMSGL.Split(")"))[0]
-            $MAXMSGL = $MAXMSGL -Replace "[(]",""
-            $MAXMSGL = $MAXMSGL.Trim()
-            #Write-Host "$MAXMSGL"         
-          }
-        }
+			  $QPropMatch4 = $QPropLine | Select-String -Pattern 'MAXMSGL\('
+			  IF ($QPropMatch4)
+			  {
+				$QPropLine4 = $QPropLine
+				$Splitter = "MAXMSGL"
+				$QPropLineSplit4 = $QPropLine4 -Split $Splitter
+				$MAXMSGL = $QPropLineSplit4[1]
+				$MAXMSGL = ($MAXMSGL.Split(")"))[0]
+				$MAXMSGL = $MAXMSGL -Replace "[(]",""
+				$MAXMSGL = $MAXMSGL.Trim()
+				#Write-Host "$MAXMSGL"         
+			  }
+			}
 
-        $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nDiscovering Queue: ($QueueName) `nQueueManagerName: ($QueueManagerName). `nTYPE: ($TYPE). `nDESCR: ($DESCR). `nMAXDEPTH: ($MAXDEPTH). `nMAXMSGL: ($MAXMSGL)")
+			$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nDiscovering Queue: ($QueueName) `nQueueManagerName: ($QueueManagerName). `nTYPE: ($TYPE). `nDESCR: ($DESCR). `nMAXDEPTH: ($MAXDEPTH). `nMAXMSGL: ($MAXMSGL)")
 
-        $instance = $DiscoveryData.CreateClassInstance("$MPElement[Name='IBM.MQ.Queue']$")
-        $instance.AddProperty("$MPElement[Name='Windows!Microsoft.Windows.Computer']/PrincipalName$",$ComputerName)
-        $instance.AddProperty("$MPElement[Name='IBM.MQ.QueueManager']/QueueManagerName$",$QueueManagerName)
-        $instance.AddProperty("$MPElement[Name='IBM.MQ.Queue']/QueueManagerName$",$QueueManagerName)
-        $instance.AddProperty("$MPElement[Name='IBM.MQ.Queue']/QueueName$",$QueueName)
-        $instance.AddProperty("$MPElement[Name='IBM.MQ.Queue']/TYPE$",$TYPE)
-        $instance.AddProperty("$MPElement[Name='IBM.MQ.Queue']/DESCR$",$DESCR)
-        $instance.AddProperty("$MPElement[Name='IBM.MQ.Queue']/MAXDEPTH$",$MAXDEPTH)
-        $instance.AddProperty("$MPElement[Name='IBM.MQ.Queue']/MAXMSGL$",$MAXMSGL)
-        $instance.AddProperty("$MPElement[Name='System!System.Entity']/DisplayName$",$QueueName)
-        $DiscoveryData.AddInstance($instance)
-      }
-    }
-  }
+			$instance = $DiscoveryData.CreateClassInstance("$MPElement[Name='IBM.MQ.Queue']$")
+			$instance.AddProperty("$MPElement[Name='Windows!Microsoft.Windows.Computer']/PrincipalName$",$ComputerName)
+			$instance.AddProperty("$MPElement[Name='IBM.MQ.QueueManager']/QueueManagerName$",$QueueManagerName)
+			$instance.AddProperty("$MPElement[Name='IBM.MQ.Queue']/QueueManagerName$",$QueueManagerName)
+			$instance.AddProperty("$MPElement[Name='IBM.MQ.Queue']/QueueName$",$QueueName)
+			$instance.AddProperty("$MPElement[Name='IBM.MQ.Queue']/TYPE$",$TYPE)
+			$instance.AddProperty("$MPElement[Name='IBM.MQ.Queue']/DESCR$",$DESCR)
+			$instance.AddProperty("$MPElement[Name='IBM.MQ.Queue']/MAXDEPTH$",$MAXDEPTH)
+			$instance.AddProperty("$MPElement[Name='IBM.MQ.Queue']/MAXMSGL$",$MAXMSGL)
+			$instance.AddProperty("$MPElement[Name='System!System.Entity']/DisplayName$",$QueueName)
+			$DiscoveryData.AddInstance($instance)
+		  }
+		}
+	  }
 
-# Return Discovery Items Normally           
-$DiscoveryData
-# Return Discovery Bag to the command line for testing (does not work from ISE)
-# $momapi.Return($DiscoveryData)
+	# Return Discovery Items Normally           
+	$DiscoveryData
+	# Return Discovery Bag to the command line for testing (does not work from ISE)
+	# $momapi.Return($DiscoveryData)
+  }	
 #=================================================================================
 # End MAIN script section
 Set-WinUILanguageOverride

--- a/IBM.MQ.xml
+++ b/IBM.MQ.xml
@@ -1,101 +1,102 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <ManagementPack ContentReadable="true" SchemaVersion="2.0" OriginalSchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-  <Manifest>
-    <Identity>
-      <ID>IBM.MQ</ID>
-      <Version>3.2.1.6</Version>
-    </Identity>
-    <Name>IBM.MQ</Name>
-    <References>
-      <Reference Alias="SC">
-        <ID>Microsoft.SystemCenter.Library</ID>
-        <Version>7.0.8433.0</Version>
-        <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
-      </Reference>
-      <Reference Alias="Windows">
-        <ID>Microsoft.Windows.Library</ID>
-        <Version>7.5.8501.0</Version>
-        <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
-      </Reference>
-      <Reference Alias="System">
-        <ID>System.Library</ID>
-        <Version>7.5.8501.0</Version>
-        <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
-      </Reference>
-      <Reference Alias="Health">
-        <ID>System.Health.Library</ID>
-        <Version>7.0.8433.0</Version>
-        <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
-      </Reference>
-      <Reference Alias="Perf">
-        <ID>System.Performance.Library</ID>
-        <Version>7.0.8433.0</Version>
-        <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
-      </Reference>
-      <Reference Alias="MSDL">
-        <ID>Microsoft.SystemCenter.DataWarehouse.Library</ID>
-        <Version>7.1.10226.0</Version>
-        <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
-      </Reference>
-    </References>
-  </Manifest>
-  <TypeDefinitions>
-    <EntityTypes>
-      <ClassTypes>
-        <ClassType ID="IBM.MQ.Channel" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
-          <Property ID="ChannelName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-          <Property ID="ChannelType" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-          <Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-        </ClassType>
-        <ClassType ID="IBM.MQ.Listener" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
-          <Property ID="ListenerName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-          <Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-        </ClassType>
-        <ClassType ID="IBM.MQ.Queue" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
-          <Property ID="DESCR" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-          <Property ID="MAXDEPTH" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-          <Property ID="MAXMSGL" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-          <Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-          <Property ID="QueueName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-          <Property ID="TYPE" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-        </ClassType>
-        <ClassType ID="IBM.MQ.QueueManager" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
-          <Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-        </ClassType>
-        <ClassType ID="IBM.MQ.Server" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.LocalApplication" Hosted="true" Singleton="false" Extension="false">
-          <Property ID="Version" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-          <Property ID="InstallPath" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
-        </ClassType>
-      </ClassTypes>
-      <RelationshipTypes>
-        <RelationshipType ID="IBM.MQ.Server.Hosts.QueueManager" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
-          <Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Server" />
-          <Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
-        </RelationshipType>
-        <RelationshipType ID="IBM.MQ.QueueManager.Hosts.Channel" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
-          <Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
-          <Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Channel" />
-        </RelationshipType>
-        <RelationshipType ID="IBM.MQ.QueueManager.Hosts.Listener" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
-          <Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
-          <Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Listener" />
-        </RelationshipType>
-        <RelationshipType ID="IBM.MQ.QueueManager.Hosts.Queue" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
-          <Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
-          <Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Queue" />
-        </RelationshipType>
-      </RelationshipTypes>
-    </EntityTypes>
+	<Manifest>
+		<Identity>
+			<ID>IBM.MQ</ID>
+			<Version>3.2.1.6</Version>
+		</Identity>
+		<Name>IBM.MQ</Name>
+		<References>
+			<Reference Alias="SC">
+				<ID>Microsoft.SystemCenter.Library</ID>
+				<Version>7.0.8433.0</Version>
+				<PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
+			</Reference>
+			<Reference Alias="Windows">
+				<ID>Microsoft.Windows.Library</ID>
+				<Version>7.5.8501.0</Version>
+				<PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
+			</Reference>
+			<Reference Alias="System">
+				<ID>System.Library</ID>
+				<Version>7.5.8501.0</Version>
+				<PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
+			</Reference>			
+			<Reference Alias="Health">
+				<ID>System.Health.Library</ID>
+				<Version>7.0.8433.0</Version>
+				<PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
+			</Reference>
+		    <Reference Alias="Perf">
+			  <ID>System.Performance.Library</ID>
+			  <Version>7.0.8433.0</Version>
+			  <PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
+		    </Reference>
+			<Reference Alias="MSDL">
+				<ID>Microsoft.SystemCenter.DataWarehouse.Library</ID>
+				<Version>7.1.10226.0</Version>
+				<PublicKeyToken>31bf3856ad364e35</PublicKeyToken>
+			</Reference>		  
+		</References>
+	</Manifest>
+	<TypeDefinitions>
+		<EntityTypes>
+			<ClassTypes>
+				<ClassType ID="IBM.MQ.Channel" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
+					<Property ID="ChannelName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+					<Property ID="ChannelType" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+					<Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+				</ClassType>
+				<ClassType ID="IBM.MQ.Listener" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
+					<Property ID="ListenerName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+					<Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+				</ClassType>
+				<ClassType ID="IBM.MQ.Queue" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
+					<Property ID="DESCR" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+					<Property ID="MAXDEPTH" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+					<Property ID="MAXMSGL" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+					<Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+					<Property ID="QueueName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+					<Property ID="TYPE" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+				</ClassType>
+				<ClassType ID="IBM.MQ.QueueManager" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.ApplicationComponent" Hosted="true" Singleton="false" Extension="false">
+					<Property ID="QueueManagerName" Type="string" AutoIncrement="false" Key="true" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+				</ClassType>
+				<ClassType ID="IBM.MQ.Server" Accessibility="Public" Abstract="false" Base="Windows!Microsoft.Windows.LocalApplication" Hosted="true" Singleton="false" Extension="false">
+					<Property ID="Version" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+					<Property ID="InstallPath" Type="string" AutoIncrement="false" Key="false" CaseSensitive="false" MaxLength="256" MinLength="0" Required="false" Scale="0" />
+				</ClassType>				
+			</ClassTypes>			
+			<RelationshipTypes>
+				<RelationshipType ID="IBM.MQ.Server.Hosts.QueueManager" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
+					<Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Server" />
+					<Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
+				</RelationshipType>
+				<RelationshipType ID="IBM.MQ.QueueManager.Hosts.Channel" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
+					<Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
+					<Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Channel" />
+				</RelationshipType>
+				<RelationshipType ID="IBM.MQ.QueueManager.Hosts.Listener" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
+					<Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
+					<Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Listener" />
+				</RelationshipType>
+				<RelationshipType ID="IBM.MQ.QueueManager.Hosts.Queue" Accessibility="Internal" Abstract="false" Base="System!System.Hosting">
+					<Source ID="Source" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.QueueManager" />
+					<Target ID="Target" MinCardinality="0" MaxCardinality="2147483647" Type="IBM.MQ.Queue" />
+				</RelationshipType>
+			</RelationshipTypes>
+		</EntityTypes>			
     <ModuleTypes>
       <DataSourceModuleType ID="IBM.MQ.QueuePerformance.Filtered.DS" Accessibility="Public" Batching="false">
         <Configuration>
-          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />		  
         </Configuration>
         <OverrideableParameters>
-          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -106,31 +107,31 @@
               </DataSource>
               <ConditionDetection ID="Filter" TypeID="System!System.ExpressionFilter">
                 <Expression>
-                  <And>
-                    <Expression>
-                      <SimpleExpression>
-                        <ValueExpression>
-                          <XPathQuery Type="String">Property[@Name='QueueName']</XPathQuery>
-                        </ValueExpression>
-                        <Operator>Equal</Operator>
-                        <ValueExpression>
-                          <Value Type="String">$Config/QueueName$</Value>
-                        </ValueExpression>
-                      </SimpleExpression>
-                    </Expression>
-                    <Expression>
-                      <SimpleExpression>
-                        <ValueExpression>
-                          <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-                        </ValueExpression>
-                        <Operator>Equal</Operator>
-                        <ValueExpression>
-                          <Value Type="String">$Config/QueueManagerName$</Value>
-                        </ValueExpression>
-                      </SimpleExpression>
-                    </Expression>
-                  </And>
-                </Expression>
+					<And>
+					  <Expression>
+						<SimpleExpression>
+						  <ValueExpression>
+							<XPathQuery Type="String">Property[@Name='QueueName']</XPathQuery>
+						  </ValueExpression>
+						  <Operator>Equal</Operator>
+						  <ValueExpression>
+							<Value Type="String">$Config/QueueName$</Value>
+						  </ValueExpression>
+						</SimpleExpression>
+					  </Expression>
+					  <Expression>
+						<SimpleExpression>
+						  <ValueExpression>
+							<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+						  </ValueExpression>
+						  <Operator>Equal</Operator>
+						  <ValueExpression>
+							<Value Type="String">$Config/QueueManagerName$</Value>
+						  </ValueExpression>
+						</SimpleExpression>
+					  </Expression>
+					</And>
+		        </Expression>
               </ConditionDetection>
             </MemberModules>
             <Composition>
@@ -141,15 +142,15 @@
           </Composite>
         </ModuleImplementation>
         <OutputType>System!System.PropertyBagData</OutputType>
-      </DataSourceModuleType>
+      </DataSourceModuleType>	
       <DataSourceModuleType ID="IBM.MQ.QueuePerformance.DS" Accessibility="Internal" Batching="false">
         <Configuration>
-          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />	
         </Configuration>
         <OverrideableParameters>
-          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -158,7 +159,7 @@
                 <Scheduler>
                   <SimpleReccuringSchedule>
                     <Interval Unit="Seconds">$Config/IntervalSeconds$</Interval>
-                    <SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
+					<SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
                   </SimpleReccuringSchedule>
                   <ExcludeDates />
                 </Scheduler>
@@ -242,9 +243,9 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $QD = $QD.Substring(0, $QD.IndexOf(')'))
           $QD = $QD -Replace "[()]",""
           $QD = $QD.Trim()
-                                [int]$QueueDepth = $QD
+		  [int]$QueueDepth = $QD
           #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) QueueDepth:($QueueDepth)"
-                                #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nQueueDepth:($QueueDepth).")
+		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nQueueDepth:($QueueDepth).")
         }
 
         #Get IPPROCS
@@ -257,9 +258,9 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $QIPPROCS = $QIPPROCS.Substring(0, $QIPPROCS.IndexOf(')'))
           $QIPPROCS = $QIPPROCS -Replace "[()]",""
           $QIPPROCS = $QIPPROCS.Trim()
-                                [int]$IPPROCS = $QIPPROCS
+		  [int]$IPPROCS = $QIPPROCS
           #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) IPPROCS:($IPPROCS)"
-                                #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nIPPROCS:($IPPROCS).")
+		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nIPPROCS:($IPPROCS).")
         }
 
         #Get OPPROCS
@@ -272,9 +273,9 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $QOPPROCS = $QOPPROCS.Substring(0, $QOPPROCS.IndexOf(')'))
           $QOPPROCS = $QOPPROCS -Replace "[()]",""
           $QOPPROCS = $QOPPROCS.Trim()
-                                [int]$OPPROCS = $QOPPROCS
+		  [int]$OPPROCS = $QOPPROCS
           #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) OPPROCS:($OPPROCS)"
-                                #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nOPPROCS:($OPPROCS).")
+		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nOPPROCS:($OPPROCS).")
         }
 
         #Get Queue MAXDEPTH
@@ -287,9 +288,9 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $QMAXDEPTH = $QMAXDEPTH.Substring(0, $QMAXDEPTH.IndexOf(')'))
           $QMAXDEPTH = $QMAXDEPTH -Replace "[()]",""
           $QMAXDEPTH = $QMAXDEPTH.Trim()
-                                [int]$MAXDEPTH = $QMAXDEPTH
+		  [int]$MAXDEPTH = $QMAXDEPTH
           #Write-Host "QueueManagerName: ($QueueManagerName) QueueName:($QueueName) MAXDEPTH:($MAXDEPTH)"
-                                #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nMAXDEPTH:($MAXDEPTH).")
+		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName) `nQueueName:($QueueName) `nMAXDEPTH:($MAXDEPTH).")
         }
       }
 
@@ -301,14 +302,14 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
       $bag = $momapi.CreatePropertyBag()
       #Create PropertyBags
       $bag.AddValue('QueueManagerName',$QueueManagerName)
-                 $bag.AddValue('QueueName',$QueueName)
-                 $bag.AddValue('QueueDepth',$QueueDepth)
-                 $bag.AddValue('MAXDEPTH',$MAXDEPTH)
-                 $bag.AddValue('QueuePercentUsed',$QueuePercentUsed)
-                 $bag.AddValue('IPPROCS',$IPPROCS)
-                 $bag.AddValue('OPPROCS',$OPPROCS)
-                 #Return each property bag as we create and populate it.
-                 $bag
+	  $bag.AddValue('QueueName',$QueueName)
+	  $bag.AddValue('QueueDepth',$QueueDepth)
+	  $bag.AddValue('MAXDEPTH',$MAXDEPTH)
+	  $bag.AddValue('QueuePercentUsed',$QueuePercentUsed)
+	  $bag.AddValue('IPPROCS',$IPPROCS)
+	  $bag.AddValue('OPPROCS',$OPPROCS)
+	  #Return each property bag as we create and populate it.
+	  $bag
     }
   }
 }
@@ -325,7 +326,8 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #=================================================================================
 # End of script
                 </ScriptBody>
-                <Parameters></Parameters>
+                <Parameters>
+                </Parameters>				
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
             </MemberModules>
@@ -340,14 +342,14 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
       </DataSourceModuleType>
       <DataSourceModuleType ID="IBM.MQ.ListenerPerformance.Filtered.DS" Accessibility="Public" Batching="false">
         <Configuration>
-          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="ListenerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="ListenerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />		  
         </Configuration>
         <OverrideableParameters>
-          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -358,31 +360,31 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
               </DataSource>
               <ConditionDetection ID="Filter" TypeID="System!System.ExpressionFilter">
                 <Expression>
-                  <And>
-                    <Expression>
-                      <SimpleExpression>
-                        <ValueExpression>
-                          <XPathQuery Type="String">Property[@Name='ListenerName']</XPathQuery>
-                        </ValueExpression>
-                        <Operator>Equal</Operator>
-                        <ValueExpression>
-                          <Value Type="String">$Config/ListenerName$</Value>
-                        </ValueExpression>
-                      </SimpleExpression>
-                    </Expression>
-                    <Expression>
-                      <SimpleExpression>
-                        <ValueExpression>
-                          <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-                        </ValueExpression>
-                        <Operator>Equal</Operator>
-                        <ValueExpression>
-                          <Value Type="String">$Config/QueueManagerName$</Value>
-                        </ValueExpression>
-                      </SimpleExpression>
-                    </Expression>
-                  </And>
-                </Expression>
+					<And>
+					  <Expression>
+						<SimpleExpression>
+						  <ValueExpression>
+							<XPathQuery Type="String">Property[@Name='ListenerName']</XPathQuery>
+						  </ValueExpression>
+						  <Operator>Equal</Operator>
+						  <ValueExpression>
+							<Value Type="String">$Config/ListenerName$</Value>
+						  </ValueExpression>
+						</SimpleExpression>
+					  </Expression>
+					  <Expression>
+						<SimpleExpression>
+						  <ValueExpression>
+							<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+						  </ValueExpression>
+						  <Operator>Equal</Operator>
+						  <ValueExpression>
+							<Value Type="String">$Config/QueueManagerName$</Value>
+						  </ValueExpression>
+						</SimpleExpression>
+					  </Expression>
+					</And>
+		        </Expression>
               </ConditionDetection>
             </MemberModules>
             <Composition>
@@ -393,15 +395,15 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
           </Composite>
         </ModuleImplementation>
         <OutputType>System!System.PropertyBagData</OutputType>
-      </DataSourceModuleType>
+      </DataSourceModuleType>	
       <DataSourceModuleType ID="IBM.MQ.ListenerPerformance.DS" Accessibility="Internal" Batching="false">
         <Configuration>
-          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />	
         </Configuration>
         <OverrideableParameters>
-          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -410,7 +412,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
                 <Scheduler>
                   <SimpleReccuringSchedule>
                     <Interval Unit="Seconds">$Config/IntervalSeconds$</Interval>
-                    <SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
+					<SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
                   </SimpleReccuringSchedule>
                   <ExcludeDates />
                 </Scheduler>
@@ -500,11 +502,11 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $bag = $momapi.CreatePropertyBag()
 
           #Create PropertyBags
-                     $bag.AddValue('QueueManagerName',$QueueManagerName)
-                     $bag.AddValue('ListenerName',$ListenerName)
-                     $bag.AddValue('LSessionsValue',$LSessionsValue)
-                     #Return each property bag as we create and populate it.
-                     $bag
+	      $bag.AddValue('QueueManagerName',$QueueManagerName)
+	      $bag.AddValue('ListenerName',$ListenerName)
+	      $bag.AddValue('LSessionsValue',$LSessionsValue)
+	      #Return each property bag as we create and populate it.
+	      $bag
         }
       }
     }
@@ -523,9 +525,10 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #=================================================================================
 # End of script
                 </ScriptBody>
-                <Parameters></Parameters>
+                <Parameters>
+                </Parameters>				
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
-             </ProbeAction>
+              </ProbeAction>
             </MemberModules>
             <Composition>
               <Node ID="PA">
@@ -535,15 +538,15 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
           </Composite>
         </ModuleImplementation>
         <OutputType>System!System.PropertyBagData</OutputType>
-      </DataSourceModuleType>
+      </DataSourceModuleType>	  
       <DataSourceModuleType ID="IBM.MQ.ChannelStatus.Monitor.DS" Accessibility="Internal" Batching="false">
         <Configuration>
-          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />	
         </Configuration>
         <OverrideableParameters>
-          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -552,7 +555,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
                 <Scheduler>
                   <SimpleReccuringSchedule>
                     <Interval Unit="Seconds">$Config/IntervalSeconds$</Interval>
-                    <SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
+					<SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
                   </SimpleReccuringSchedule>
                   <ExcludeDates />
                 </Scheduler>
@@ -636,16 +639,16 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $CStatus = $CStatus -Replace "[()]",""
           $CStatus = $CStatus.Trim()
           #Write-Host "CStatus: ($CStatus)"
-                                #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName). `nChannelName:($ChannelName). `nChannelStatus:($CStatus).")
+		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName). `nChannelName:($ChannelName). `nChannelStatus:($CStatus).")
 
           # Load PropertyBag function 
           $bag = $momapi.CreatePropertyBag()
           #Create PropertyBags
-                     $bag.AddValue('QueueManagerName',$QueueManagerName)
-                     $bag.AddValue('ChannelName',$ChannelName)
-                     $bag.AddValue('CStatus',$CStatus)
-                     #Return each property bag as we create and populate it.
-                     $bag
+	      $bag.AddValue('QueueManagerName',$QueueManagerName)
+	      $bag.AddValue('ChannelName',$ChannelName)
+	      $bag.AddValue('CStatus',$CStatus)
+	      #Return each property bag as we create and populate it.
+	      $bag
 
           #Break out of this loop in the case there might be 
           #multiple channels returned for a single channel name
@@ -669,7 +672,8 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #=================================================================================
 # End of script
                 </ScriptBody>
-                <Parameters></Parameters>
+                <Parameters>
+                </Parameters>				
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
             </MemberModules>
@@ -684,12 +688,12 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
       </DataSourceModuleType>
       <DataSourceModuleType ID="IBM.MQ.ListenerStatus.Monitor.DS" Accessibility="Internal" Batching="false">
         <Configuration>
-          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />	
         </Configuration>
         <OverrideableParameters>
-          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
@@ -698,7 +702,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
                 <Scheduler>
                   <SimpleReccuringSchedule>
                     <Interval Unit="Seconds">$Config/IntervalSeconds$</Interval>
-                    <SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
+					<SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
                   </SimpleReccuringSchedule>
                   <ExcludeDates />
                 </Scheduler>
@@ -780,16 +784,16 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
           $LStatus = $LStatus -Replace "[()]",""
           $LStatus = $LStatus.Trim()
           #Write-Host "LStatus: ($LStatus)"
-                                #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName). `nListenerName:($ListenerName). `nListenerStatus:($LStatus).")
+		  #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nQueueManagerName:($QueueManagerName). `nListenerName:($ListenerName). `nListenerStatus:($LStatus).")
 
           # Load PropertyBag function 
           $bag = $momapi.CreatePropertyBag()
           #Create PropertyBags
-                     $bag.AddValue('QueueManagerName',$QueueManagerName)
-                     $bag.AddValue('ListenerName',$ListenerName)
-                     $bag.AddValue('LStatus',$LStatus)
-                     #Return each property bag as we create and populate it.
-                     $bag
+	      $bag.AddValue('QueueManagerName',$QueueManagerName)
+	      $bag.AddValue('ListenerName',$ListenerName)
+	      $bag.AddValue('LStatus',$LStatus)
+	      #Return each property bag as we create and populate it.
+	      $bag
         }
       }
     }
@@ -808,7 +812,8 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #=================================================================================
 # End of script
                 </ScriptBody>
-                <Parameters></Parameters>
+                <Parameters>
+                </Parameters>				
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
             </MemberModules>
@@ -823,21 +828,21 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
       </DataSourceModuleType>
       <DataSourceModuleType ID="IBM.MQ.QueueManagerStatus.Monitor.DS" Accessibility="Internal" Batching="false">
         <Configuration>
-          <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />	
         </Configuration>
         <OverrideableParameters>
-          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <ModuleImplementation Isolation="Any">
           <Composite>
-           <MemberModules>
+            <MemberModules>
               <DataSource ID="Scheduler" TypeID="System!System.Scheduler">
                 <Scheduler>
                   <SimpleReccuringSchedule>
                     <Interval Unit="Seconds">$Config/IntervalSeconds$</Interval>
-                   <SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
+					<SpreadInitializationOverInterval Unit="Seconds">$Config/IntervalSeconds$</SpreadInitializationOverInterval>
                   </SimpleReccuringSchedule>
                   <ExcludeDates />
                 </Scheduler>
@@ -902,7 +907,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
   $bag = $momapi.CreatePropertyBag()
   #Create PropertyBags
   $bag.AddValue('QueueManagerName',$QueueManagerName)
- $bag.AddValue('QMGRStatus',$QMGRStatus)
+  $bag.AddValue('QMGRStatus',$QMGRStatus)
   #Return each property bag as we create and populate it.
   $bag
 }
@@ -919,7 +924,8 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #=================================================================================
 # End of script
                 </ScriptBody>
-                <Parameters></Parameters>
+                <Parameters>
+                </Parameters>				
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
             </MemberModules>
@@ -938,42 +944,42 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
         <MonitorTypeStates>
           <MonitorTypeState ID="Error" NoDetection="false" />
           <MonitorTypeState ID="Warning" NoDetection="false" />
-          <MonitorTypeState ID="Success" NoDetection="false" />
+		  <MonitorTypeState ID="Success" NoDetection="false" />
         </MonitorTypeStates>
         <Configuration>
           <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
           <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:integer" name="WarningThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:integer" name="CriticalThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="WarningThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="CriticalThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />		  
         </Configuration>
         <OverrideableParameters>
-          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="WarningThreshold" Selector="$Config/WarningThreshold$" ParameterType="int" />
-          <OverrideableParameter ID="CriticalThreshold" Selector="$Config/CriticalThreshold$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="WarningThreshold" Selector="$Config/WarningThreshold$" ParameterType="int" />
+		  <OverrideableParameter ID="CriticalThreshold" Selector="$Config/CriticalThreshold$" ParameterType="int" />		  
         </OverrideableParameters>
         <MonitorImplementation>
           <MemberModules>
             <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
-              <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+			  <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+			  <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               <QueueName>$Config/QueueName$</QueueName>
-              <QueueManagerName>$Config/QueueManagerName$</QueueManagerName>
+		      <QueueManagerName>$Config/QueueManagerName$</QueueManagerName>			  
             </DataSource>
             <ConditionDetection ID="HealthyCondition" TypeID="System!System.ExpressionFilter">
-              <Expression>
-                <SimpleExpression>
-                  <ValueExpression>
-                    <XPathQuery Type="Integer">Property[@Name='QueueDepth']</XPathQuery>
-                  </ValueExpression>
-                  <Operator>Less</Operator>
-                  <ValueExpression>
-                    <Value Type="Integer">$Config/WarningThreshold$</Value>
-                  </ValueExpression>
-                </SimpleExpression>
-              </Expression>
+			  <Expression>
+				<SimpleExpression>
+				  <ValueExpression>
+					<XPathQuery Type="Integer">Property[@Name='QueueDepth']</XPathQuery>
+				  </ValueExpression>
+				  <Operator>Less</Operator>
+				  <ValueExpression>
+					<Value Type="Integer">$Config/WarningThreshold$</Value>
+				  </ValueExpression>
+				</SimpleExpression>
+			  </Expression>
             </ConditionDetection>
             <ConditionDetection ID="WarningCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
@@ -1000,21 +1006,21 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
                       </ValueExpression>
                     </SimpleExpression>
                   </Expression>
-                </And>
-              </Expression>
-            </ConditionDetection>
+				</And>
+		      </Expression>				  
+            </ConditionDetection>			
             <ConditionDetection ID="CriticalCondition" TypeID="System!System.ExpressionFilter">
-              <Expression>
-                <SimpleExpression>
-                  <ValueExpression>
-                    <XPathQuery Type="Integer">Property[@Name='QueueDepth']</XPathQuery>
-                  </ValueExpression>
-                  <Operator>GreaterEqual</Operator>
-                  <ValueExpression>
-                    <Value Type="Integer">$Config/CriticalThreshold$</Value>
-                  </ValueExpression>
-                </SimpleExpression>
-              </Expression>
+			  <Expression>
+				<SimpleExpression>
+				  <ValueExpression>
+					<XPathQuery Type="Integer">Property[@Name='QueueDepth']</XPathQuery>
+				  </ValueExpression>
+				  <Operator>GreaterEqual</Operator>
+				  <ValueExpression>
+					<Value Type="Integer">$Config/CriticalThreshold$</Value>
+				  </ValueExpression>
+				</SimpleExpression>
+			  </Expression>
             </ConditionDetection>
           </MemberModules>
           <RegularDetections>
@@ -1040,42 +1046,42 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
         <MonitorTypeStates>
           <MonitorTypeState ID="Error" NoDetection="false" />
           <MonitorTypeState ID="Warning" NoDetection="false" />
-          <MonitorTypeState ID="Success" NoDetection="false" />
+		  <MonitorTypeState ID="Success" NoDetection="false" />
         </MonitorTypeStates>
         <Configuration>
           <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
           <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:integer" name="WarningThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:integer" name="CriticalThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="WarningThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:integer" name="CriticalThreshold" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />		  
         </Configuration>
         <OverrideableParameters>
-          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="WarningThreshold" Selector="$Config/WarningThreshold$" ParameterType="int" />
-          <OverrideableParameter ID="CriticalThreshold" Selector="$Config/CriticalThreshold$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="WarningThreshold" Selector="$Config/WarningThreshold$" ParameterType="int" />
+		  <OverrideableParameter ID="CriticalThreshold" Selector="$Config/CriticalThreshold$" ParameterType="int" />		  
         </OverrideableParameters>
         <MonitorImplementation>
           <MemberModules>
             <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
-              <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+			  <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+			  <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               <QueueName>$Config/QueueName$</QueueName>
-              <QueueManagerName>$Config/QueueManagerName$</QueueManagerName>
+		      <QueueManagerName>$Config/QueueManagerName$</QueueManagerName>			  
             </DataSource>
             <ConditionDetection ID="HealthyCondition" TypeID="System!System.ExpressionFilter">
-              <Expression>
-                <SimpleExpression>
-                  <ValueExpression>
-                    <XPathQuery Type="Integer">Property[@Name='QueuePercentUsed']</XPathQuery>
-                  </ValueExpression>
-                  <Operator>Less</Operator>
-                  <ValueExpression>
-                    <Value Type="Integer">$Config/WarningThreshold$</Value>
-                  </ValueExpression>
-                </SimpleExpression>
-              </Expression>
+			  <Expression>
+				<SimpleExpression>
+				  <ValueExpression>
+					<XPathQuery Type="Integer">Property[@Name='QueuePercentUsed']</XPathQuery>
+				  </ValueExpression>
+				  <Operator>Less</Operator>
+				  <ValueExpression>
+					<Value Type="Integer">$Config/WarningThreshold$</Value>
+				  </ValueExpression>
+				</SimpleExpression>
+			  </Expression>
             </ConditionDetection>
             <ConditionDetection ID="WarningCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
@@ -1102,21 +1108,21 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
                       </ValueExpression>
                     </SimpleExpression>
                   </Expression>
-                </And>
-              </Expression>
-            </ConditionDetection>
+				</And>
+		      </Expression>				  
+            </ConditionDetection>			
             <ConditionDetection ID="CriticalCondition" TypeID="System!System.ExpressionFilter">
-              <Expression>
-                <SimpleExpression>
-                  <ValueExpression>
-                    <XPathQuery Type="Integer">Property[@Name='QueuePercentUsed']</XPathQuery>
-                  </ValueExpression>
-                  <Operator>GreaterEqual</Operator>
-                  <ValueExpression>
-                    <Value Type="Integer">$Config/CriticalThreshold$</Value>
-                  </ValueExpression>
-                </SimpleExpression>
-              </Expression>
+			  <Expression>
+				<SimpleExpression>
+				  <ValueExpression>
+					<XPathQuery Type="Integer">Property[@Name='QueuePercentUsed']</XPathQuery>
+				  </ValueExpression>
+				  <Operator>GreaterEqual</Operator>
+				  <ValueExpression>
+					<Value Type="Integer">$Config/CriticalThreshold$</Value>
+				  </ValueExpression>
+				</SimpleExpression>
+			  </Expression>
             </ConditionDetection>
           </MemberModules>
           <RegularDetections>
@@ -1137,55 +1143,55 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
             </RegularDetection>
           </RegularDetections>
         </MonitorImplementation>
-      </UnitMonitorType>
+      </UnitMonitorType>	  
       <UnitMonitorType ID="IBM.MQ.QueueIPPROCS.Monitor.MonitorType" Accessibility="Internal">
         <MonitorTypeStates>
           <MonitorTypeState ID="Error" NoDetection="false" />
-          <MonitorTypeState ID="Success" NoDetection="false" />
+		  <MonitorTypeState ID="Success" NoDetection="false" />
         </MonitorTypeStates>
         <Configuration>
           <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
           <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="QueueName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <MonitorImplementation>
           <MemberModules>
             <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
-              <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+			  <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+			  <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               <QueueName>$Config/QueueName$</QueueName>
-              <QueueManagerName>$Config/QueueManagerName$</QueueManagerName>
+		      <QueueManagerName>$Config/QueueManagerName$</QueueManagerName>
             </DataSource>
             <ConditionDetection ID="HealthyCondition" TypeID="System!System.ExpressionFilter">
-              <Expression>
-                <SimpleExpression>
-                  <ValueExpression>
-                    <XPathQuery Type="Integer">Property[@Name='IPPROCS']</XPathQuery>
-                 </ValueExpression>
-                  <Operator>Greater</Operator>
-                  <ValueExpression>
-                    <Value Type="Integer">0</Value>
-                  </ValueExpression>
-                </SimpleExpression>
-              </Expression>
+			  <Expression>
+				<SimpleExpression>
+				  <ValueExpression>
+					<XPathQuery Type="Integer">Property[@Name='IPPROCS']</XPathQuery>
+				  </ValueExpression>
+				  <Operator>Greater</Operator>
+				  <ValueExpression>
+					<Value Type="Integer">0</Value>
+				  </ValueExpression>
+				</SimpleExpression>
+			  </Expression>
             </ConditionDetection>
             <ConditionDetection ID="UnhealthyCondition" TypeID="System!System.ExpressionFilter">
-              <Expression>
-                <SimpleExpression>
-                  <ValueExpression>
-                    <XPathQuery Type="Integer">Property[@Name='IPPROCS']</XPathQuery>
-                  </ValueExpression>
-                  <Operator>Equal</Operator>
-                  <ValueExpression>
-                    <Value Type="Integer">0</Value>
-                  </ValueExpression>
-                </SimpleExpression>
-              </Expression>
+			  <Expression>
+				<SimpleExpression>
+				  <ValueExpression>
+					<XPathQuery Type="Integer">Property[@Name='IPPROCS']</XPathQuery>
+				  </ValueExpression>
+				  <Operator>Equal</Operator>
+				  <ValueExpression>
+					<Value Type="Integer">0</Value>
+				  </ValueExpression>
+				</SimpleExpression>
+			  </Expression>
             </ConditionDetection>
           </MemberModules>
           <RegularDetections>
@@ -1201,153 +1207,153 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
             </RegularDetection>
           </RegularDetections>
         </MonitorImplementation>
-      </UnitMonitorType>
+      </UnitMonitorType>	  
       <UnitMonitorType ID="IBM.MQ.ChannelStatus.Monitor.MonitorType" Accessibility="Internal">
         <MonitorTypeStates>
           <MonitorTypeState ID="Error" NoDetection="false" />
-          <MonitorTypeState ID="Success" NoDetection="false" />
+		  <MonitorTypeState ID="Success" NoDetection="false" />
         </MonitorTypeStates>
         <Configuration>
           <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="ChannelName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="ChannelName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
           <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-         <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <MonitorImplementation>
           <MemberModules>
             <DataSource ID="DS" TypeID="IBM.MQ.ChannelStatus.Monitor.DS">
-              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
-              <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+			  <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+			  <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
             </DataSource>
             <ConditionDetection ID="HealthyCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
-                <And>
-                  <Expression>
-                    <Or>
-                      <Expression>
-                        <SimpleExpression>
-                          <ValueExpression>
-                            <XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
-                          </ValueExpression>
-                          <Operator>Equal</Operator>
-                          <ValueExpression>
-                            <Value Type="String">RUNNING</Value>
-                          </ValueExpression>
-                        </SimpleExpression>
-                     </Expression>
-                      <Expression>
-                        <SimpleExpression>
-                          <ValueExpression>
-                            <XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
-                          </ValueExpression>
-                          <Operator>Equal</Operator>
-                          <ValueExpression>
-                            <Value Type="String">INACTIVE</Value>
-                          </ValueExpression>
-                        </SimpleExpression>
-                      </Expression>
-                      <Expression>
-                        <SimpleExpression>
-                          <ValueExpression>
-                            <XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
-                          </ValueExpression>
-                          <Operator>Equal</Operator>
-                          <ValueExpression>
-                            <Value Type="String">Not Available</Value>
-                          </ValueExpression>
-                        </SimpleExpression>
-                      </Expression>
-                    </Or>
-                  </Expression>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='ChannelName']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>Equal</Operator>
-                      <ValueExpression>
-                        <Value Type="String">$Config/ChannelName$</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>Equal</Operator>
-                      <ValueExpression>
-                        <Value Type="String">$Config/QueueManagerName$</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                </And>
-              </Expression>
+				  <And>
+					  <Expression>			  
+						<Or>
+							<Expression>
+								<SimpleExpression>
+									<ValueExpression>
+										<XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
+									</ValueExpression>
+									<Operator>Equal</Operator>
+									<ValueExpression>
+										<Value Type="String">RUNNING</Value>
+									</ValueExpression>
+								</SimpleExpression>
+							</Expression>
+							<Expression>
+								<SimpleExpression>
+									<ValueExpression>
+										<XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
+									</ValueExpression>
+									<Operator>Equal</Operator>
+									<ValueExpression>
+										<Value Type="String">INACTIVE</Value>
+									</ValueExpression>
+								</SimpleExpression>
+							</Expression>
+							<Expression>
+								<SimpleExpression>
+									<ValueExpression>
+										<XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
+									</ValueExpression>
+									<Operator>Equal</Operator>
+									<ValueExpression>
+										<Value Type="String">Not Available</Value>
+									</ValueExpression>
+								</SimpleExpression>
+							</Expression>
+						</Or>
+					  </Expression>
+					  <Expression>
+						<SimpleExpression>
+						  <ValueExpression>
+							<XPathQuery Type="String">Property[@Name='ChannelName']</XPathQuery>
+						  </ValueExpression>
+						  <Operator>Equal</Operator>
+						  <ValueExpression>
+							<Value Type="String">$Config/ChannelName$</Value>
+						  </ValueExpression>
+						</SimpleExpression>
+					  </Expression>
+					  <Expression>
+						<SimpleExpression>
+						  <ValueExpression>
+							<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+						  </ValueExpression>
+						  <Operator>Equal</Operator>
+						  <ValueExpression>
+							<Value Type="String">$Config/QueueManagerName$</Value>
+						  </ValueExpression>
+						</SimpleExpression>
+					  </Expression>
+				  </And>
+			  </Expression>			  
             </ConditionDetection>
             <ConditionDetection ID="UnhealthyCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
-                <And>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>NotEqual</Operator>
-                      <ValueExpression>
-                        <Value Type="String">RUNNING</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>NotEqual</Operator>
-                      <ValueExpression>
-                        <Value Type="String">INACTIVE</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>NotEqual</Operator>
-                      <ValueExpression>
-                        <Value Type="String">Not Available</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='ChannelName']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>Equal</Operator>
-                      <ValueExpression>
-                        <Value Type="String">$Config/ChannelName$</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>Equal</Operator>
-                      <ValueExpression>
-                        <Value Type="String">$Config/QueueManagerName$</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                </And>
-              </Expression>
+				<And>
+					<Expression>
+						<SimpleExpression>
+							<ValueExpression>
+								<XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
+							</ValueExpression>
+							<Operator>NotEqual</Operator>
+							<ValueExpression>
+								<Value Type="String">RUNNING</Value>
+							</ValueExpression>
+						</SimpleExpression>
+					</Expression>
+					<Expression>
+						<SimpleExpression>
+							<ValueExpression>
+								<XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
+							</ValueExpression>
+							<Operator>NotEqual</Operator>
+							<ValueExpression>
+								<Value Type="String">INACTIVE</Value>
+							</ValueExpression>
+						</SimpleExpression>
+					</Expression>
+					<Expression>
+						<SimpleExpression>
+							<ValueExpression>
+								<XPathQuery Type="String">Property[@Name='CStatus']</XPathQuery>
+							</ValueExpression>
+							<Operator>NotEqual</Operator>
+							<ValueExpression>
+								<Value Type="String">Not Available</Value>
+							</ValueExpression>
+						</SimpleExpression>
+					</Expression>
+				  <Expression>
+					<SimpleExpression>
+					  <ValueExpression>
+						<XPathQuery Type="String">Property[@Name='ChannelName']</XPathQuery>
+					  </ValueExpression>
+					  <Operator>Equal</Operator>
+					  <ValueExpression>
+						<Value Type="String">$Config/ChannelName$</Value>
+					  </ValueExpression>
+					</SimpleExpression>
+				  </Expression>
+				  <Expression>
+					<SimpleExpression>
+					  <ValueExpression>
+						<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+					  </ValueExpression>
+					  <Operator>Equal</Operator>
+					  <ValueExpression>
+						<Value Type="String">$Config/QueueManagerName$</Value>
+					  </ValueExpression>
+					</SimpleExpression>
+				  </Expression>					
+				</And>
+		      </Expression>				  
             </ConditionDetection>
           </MemberModules>
           <RegularDetections>
@@ -1367,101 +1373,101 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
       <UnitMonitorType ID="IBM.MQ.ListenerStatus.Monitor.MonitorType" Accessibility="Internal">
         <MonitorTypeStates>
           <MonitorTypeState ID="Error" NoDetection="false" />
-          <MonitorTypeState ID="Success" NoDetection="false" />
+		  <MonitorTypeState ID="Success" NoDetection="false" />
         </MonitorTypeStates>
         <Configuration>
           <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="ListenerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="ListenerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
           <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <MonitorImplementation>
           <MemberModules>
             <DataSource ID="DS" TypeID="IBM.MQ.ListenerStatus.Monitor.DS">
-              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
-              <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+			  <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+			  <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
             </DataSource>
             <ConditionDetection ID="HealthyCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
-                <And>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='LStatus']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>Equal</Operator>
-                      <ValueExpression>
-                        <Value Type="String">RUNNING</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                  <Expression>
-                    <SimpleExpression>
-                     <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='ListenerName']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>Equal</Operator>
-                      <ValueExpression>
-                        <Value Type="String">$Config/ListenerName$</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>Equal</Operator>
-                      <ValueExpression>
-                        <Value Type="String">$Config/QueueManagerName$</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                </And>
-              </Expression>
+				<And>
+				  <Expression>
+					<SimpleExpression>
+						<ValueExpression>
+							<XPathQuery Type="String">Property[@Name='LStatus']</XPathQuery>
+						</ValueExpression>
+						<Operator>Equal</Operator>
+						<ValueExpression>
+							<Value Type="String">RUNNING</Value>
+						</ValueExpression>
+					</SimpleExpression>
+				  </Expression>
+				  <Expression>
+					<SimpleExpression>
+					  <ValueExpression>
+						<XPathQuery Type="String">Property[@Name='ListenerName']</XPathQuery>
+					  </ValueExpression>
+					  <Operator>Equal</Operator>
+					  <ValueExpression>
+						<Value Type="String">$Config/ListenerName$</Value>
+					  </ValueExpression>
+					</SimpleExpression>
+				  </Expression>
+				  <Expression>
+					<SimpleExpression>
+					  <ValueExpression>
+						<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+					  </ValueExpression>
+					  <Operator>Equal</Operator>
+					  <ValueExpression>
+						<Value Type="String">$Config/QueueManagerName$</Value>
+					  </ValueExpression>
+					</SimpleExpression>
+				  </Expression>
+				</And>
+			  </Expression>			  
             </ConditionDetection>
             <ConditionDetection ID="UnhealthyCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
-                <And>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='LStatus']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>NotEqual</Operator>
-                      <ValueExpression>
-                        <Value Type="String">RUNNING</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='ListenerName']</XPathQuery>
-                      </ValueExpression>
-                     <Operator>Equal</Operator>
-                      <ValueExpression>
-                        <Value Type="String">$Config/ListenerName$</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>Equal</Operator>
-                      <ValueExpression>
-                        <Value Type="String">$Config/QueueManagerName$</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                </And>
-              </Expression>
+				<And>
+				  <Expression>
+					<SimpleExpression>
+						<ValueExpression>
+							<XPathQuery Type="String">Property[@Name='LStatus']</XPathQuery>
+						</ValueExpression>
+						<Operator>NotEqual</Operator>
+						<ValueExpression>
+							<Value Type="String">RUNNING</Value>
+						</ValueExpression>
+					</SimpleExpression>
+				  </Expression>
+				  <Expression>
+					<SimpleExpression>
+					  <ValueExpression>
+						<XPathQuery Type="String">Property[@Name='ListenerName']</XPathQuery>
+					  </ValueExpression>
+					  <Operator>Equal</Operator>
+					  <ValueExpression>
+						<Value Type="String">$Config/ListenerName$</Value>
+					  </ValueExpression>
+					</SimpleExpression>
+				  </Expression>
+				  <Expression>
+					<SimpleExpression>
+					  <ValueExpression>
+						<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+					  </ValueExpression>
+					  <Operator>Equal</Operator>
+					  <ValueExpression>
+						<Value Type="String">$Config/QueueManagerName$</Value>
+					  </ValueExpression>
+					</SimpleExpression>
+				  </Expression>					
+				</And>
+		      </Expression>				  
             </ConditionDetection>
           </MemberModules>
           <RegularDetections>
@@ -1479,84 +1485,84 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
         </MonitorImplementation>
       </UnitMonitorType>
       <UnitMonitorType ID="IBM.MQ.QueueManagerStatus.Monitor.MonitorType" Accessibility="Internal">
-       <MonitorTypeStates>
+        <MonitorTypeStates>
           <MonitorTypeState ID="Error" NoDetection="false" />
-          <MonitorTypeState ID="Success" NoDetection="false" />
+		  <MonitorTypeState ID="Success" NoDetection="false" />
         </MonitorTypeStates>
         <Configuration>
           <xsd:element minOccurs="1" type="xsd:integer" name="IntervalSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-          <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+		  <xsd:element minOccurs="1" type="xsd:string" name="QueueManagerName" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
           <xsd:element minOccurs="1" type="xsd:integer" name="TimeoutSeconds" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
         </Configuration>
         <OverrideableParameters>
-          <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
-          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="IntervalSeconds" Selector="$Config/IntervalSeconds$" ParameterType="int" />
+		  <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
         </OverrideableParameters>
         <MonitorImplementation>
           <MemberModules>
             <DataSource ID="DS" TypeID="IBM.MQ.QueueManagerStatus.Monitor.DS">
-              <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
-              <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+			  <IntervalSeconds>$Config/IntervalSeconds$</IntervalSeconds>
+			  <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
             </DataSource>
             <ConditionDetection ID="HealthyCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
-                <And>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='QMGRStatus']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>Equal</Operator>
-                      <ValueExpression>
-                        <Value Type="String">Running</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>Equal</Operator>
-                      <ValueExpression>
-                        <Value Type="String">$Config/QueueManagerName$</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                </And>
-              </Expression>
+				<And>
+				  <Expression>
+					<SimpleExpression>
+						<ValueExpression>
+							<XPathQuery Type="String">Property[@Name='QMGRStatus']</XPathQuery>
+						</ValueExpression>
+						<Operator>Equal</Operator>
+						<ValueExpression>
+							<Value Type="String">Running</Value>
+						</ValueExpression>
+					</SimpleExpression>
+				  </Expression>
+				  <Expression>
+					<SimpleExpression>
+					  <ValueExpression>
+						<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+					  </ValueExpression>
+					  <Operator>Equal</Operator>
+					  <ValueExpression>
+						<Value Type="String">$Config/QueueManagerName$</Value>
+					  </ValueExpression>
+					</SimpleExpression>
+				  </Expression>
+				</And>
+			  </Expression>			  
             </ConditionDetection>
             <ConditionDetection ID="UnhealthyCondition" TypeID="System!System.ExpressionFilter">
               <Expression>
-                <And>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='QMGRStatus']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>NotEqual</Operator>
-                      <ValueExpression>
-                        <Value Type="String">Running</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                  <Expression>
-                    <SimpleExpression>
-                      <ValueExpression>
-                        <XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
-                      </ValueExpression>
-                      <Operator>Equal</Operator>
-                      <ValueExpression>
-                        <Value Type="String">$Config/QueueManagerName$</Value>
-                      </ValueExpression>
-                    </SimpleExpression>
-                  </Expression>
-                </And>
-              </Expression>
+				<And>
+				  <Expression>
+					<SimpleExpression>
+						<ValueExpression>
+							<XPathQuery Type="String">Property[@Name='QMGRStatus']</XPathQuery>
+						</ValueExpression>
+						<Operator>NotEqual</Operator>
+						<ValueExpression>
+							<Value Type="String">Running</Value>
+						</ValueExpression>
+					</SimpleExpression>
+				  </Expression>
+				  <Expression>
+					<SimpleExpression>
+					  <ValueExpression>
+						<XPathQuery Type="String">Property[@Name='QueueManagerName']</XPathQuery>
+					  </ValueExpression>
+					  <Operator>Equal</Operator>
+					  <ValueExpression>
+						<Value Type="String">$Config/QueueManagerName$</Value>
+					  </ValueExpression>
+					</SimpleExpression>
+				  </Expression>					
+				</And>
+		      </Expression>				  
             </ConditionDetection>
           </MemberModules>
           <RegularDetections>
-           <RegularDetection MonitorTypeStateID="Error">
+            <RegularDetection MonitorTypeStateID="Error">
               <Node ID="UnhealthyCondition">
                 <Node ID="DS" />
               </Node>
@@ -1568,32 +1574,32 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
             </RegularDetection>
           </RegularDetections>
         </MonitorImplementation>
-      </UnitMonitorType>
-    </MonitorTypes>
-  </TypeDefinitions>
-  <Monitoring>
-    <Discoveries>
-      <Discovery ID="IBM.MQ.Channel.Discovery" Enabled="true" Target="IBM.MQ.QueueManager" ConfirmDelivery="false" Remotable="true" Priority="Normal">
-        <Category>Discovery</Category>
-        <DiscoveryTypes>
-          <DiscoveryClass TypeID="IBM.MQ.Channel">
-            <Property TypeID="IBM.MQ.Channel" PropertyID="ChannelName" />
-            <Property TypeID="IBM.MQ.Channel" PropertyID="ChannelType" />
-            <Property TypeID="IBM.MQ.Channel" PropertyID="QueueManagerName" />
-          </DiscoveryClass>
-        </DiscoveryTypes>
-        <DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
-          <IntervalSeconds>86405</IntervalSeconds>
-          <SyncTime />
-          <ScriptName>IBM.MQ.Channel.Discovery.ps1</ScriptName>
-          <ScriptBody>
+      </UnitMonitorType>	  
+    </MonitorTypes>	
+	</TypeDefinitions>
+	<Monitoring>
+		<Discoveries>
+			<Discovery ID="IBM.MQ.Channel.Discovery" Enabled="true" Target="IBM.MQ.QueueManager" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+				<Category>Discovery</Category>
+				<DiscoveryTypes>
+					<DiscoveryClass TypeID="IBM.MQ.Channel">
+						<Property TypeID="IBM.MQ.Channel" PropertyID="ChannelName" />
+						<Property TypeID="IBM.MQ.Channel" PropertyID="ChannelType" />						
+						<Property TypeID="IBM.MQ.Channel" PropertyID="QueueManagerName" />
+					</DiscoveryClass>
+				</DiscoveryTypes>
+				<DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
+				  <IntervalSeconds>86405</IntervalSeconds>
+				  <SyncTime />
+				  <ScriptName>IBM.MQ.Channel.Discovery.ps1</ScriptName>
+				  <ScriptBody>
 #=================================================================================
 #  Discover IBM MQ Channel Discovery
 #
 #  Author: Kevin Holman
 #  v1.2
 #=================================================================================
-param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName,$InstallPath)
+param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName)
 
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
@@ -1625,21 +1631,21 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #Log script event that we are starting task
 $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script is starting. `n Running as ($whoami).")
 #=================================================================================
-                                            
+			
 
 # Discovery Script section - Discovery scripts get this
 #=================================================================================
 # Load SCOM Discovery module
 $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
-#=================================================================================               
+#=================================================================================	
 
 
 # Begin MAIN script section
 #=================================================================================
 #Get the Channel from QueueManager
-$Ccmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display channel(*) | runmqsc $QueueManagerName'"
-$Cout = Invoke-Expression "$Ccmd"
+$Ccmd = "cmd /c 'echo Display channel(*) | runmqsc $QueueManagerName'"
 
+$Cout = Invoke-Expression $Ccmd
 FOREACH ($CLine in $Cout)
 {
   $Cmatch = $CLine | Select-String -Pattern 'CHANNEL\(' -CaseSensitive
@@ -1659,7 +1665,7 @@ FOREACH ($CLine in $Cout)
     $instance.AddProperty("$MPElement[Name='IBM.MQ.QueueManager']/QueueManagerName$",$QueueManagerName)
     $instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/ChannelName$",$ChannelName)
     $instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/ChannelType$",$ChannelType)
-    $instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/QueueManagerName$",$QueueManagerName)               
+    $instance.AddProperty("$MPElement[Name='IBM.MQ.Channel']/QueueManagerName$",$QueueManagerName)	
     $instance.AddProperty("$MPElement[Name='System!System.Entity']/DisplayName$", $ChannelName)
     $DiscoveryData.AddInstance($instance)
   }
@@ -1682,51 +1688,47 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 #=================================================================================
 # End of script
 </ScriptBody>
-          <Parameters>
-            <Parameter>
-              <Name>SourceID</Name>
-              <Value>$MPElement$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>ManagedEntityID</Name>
-              <Value>$Target/Id$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>ComputerName</Name>
-              <Value>$Target/Host/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>QueueManagerName</Name>
-              <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>InstallPath</Name>
-              <Value>$Target/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
-            </Parameter>
-          </Parameters>
-          <TimeoutSeconds>300</TimeoutSeconds>
-        </DataSource>
-      </Discovery>
-      <Discovery ID="IBM.MQ.Listener.Discovery" Enabled="true" Target="IBM.MQ.QueueManager" ConfirmDelivery="false" Remotable="true" Priority="Normal">
-        <Category>Discovery</Category>
-        <DiscoveryTypes>
-          <DiscoveryClass TypeID="IBM.MQ.Listener">
-            <Property TypeID="IBM.MQ.Listener" PropertyID="ListenerName" />
-            <Property TypeID="IBM.MQ.Listener" PropertyID="QueueManagerName" />
-          </DiscoveryClass>
-        </DiscoveryTypes>
-        <DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
-         <IntervalSeconds>86403</IntervalSeconds>
-          <SyncTime />
-          <ScriptName>IBM.MQ.Listener.Discovery.ps1</ScriptName>
-          <ScriptBody>
+				  <Parameters>
+					<Parameter>
+					  <Name>SourceID</Name>
+					  <Value>$MPElement$</Value>
+					</Parameter>
+					<Parameter>
+					  <Name>ManagedEntityID</Name>
+					  <Value>$Target/Id$</Value>
+					</Parameter>
+					<Parameter>
+					  <Name>ComputerName</Name>
+					  <Value>$Target/Host/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+					</Parameter>
+					<Parameter>
+					  <Name>QueueManagerName</Name>
+					  <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
+					</Parameter>					
+				  </Parameters>
+				  <TimeoutSeconds>300</TimeoutSeconds>
+				</DataSource>				
+			</Discovery>
+			<Discovery ID="IBM.MQ.Listener.Discovery" Enabled="true" Target="IBM.MQ.QueueManager" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+				<Category>Discovery</Category>
+				<DiscoveryTypes>
+					<DiscoveryClass TypeID="IBM.MQ.Listener">
+						<Property TypeID="IBM.MQ.Listener" PropertyID="ListenerName" />
+						<Property TypeID="IBM.MQ.Listener" PropertyID="QueueManagerName" />
+					</DiscoveryClass>
+				</DiscoveryTypes>
+				<DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
+				  <IntervalSeconds>86403</IntervalSeconds>
+				  <SyncTime />
+				  <ScriptName>IBM.MQ.Listener.Discovery.ps1</ScriptName>
+				  <ScriptBody>
 #=================================================================================
 #  Discover IBM MQ Queue Listener Discovery
 #
 #  Author: Kevin Holman
 #  v1.1
 #=================================================================================
-param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName,$InstallPath)
+param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName)
 
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
@@ -1758,21 +1760,21 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #Log script event that we are starting task
 $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script is starting. `n Running as ($whoami).")
 #=================================================================================
-                                            
+			
 
 # Discovery Script section - Discovery scripts get this
 #=================================================================================
 # Load SCOM Discovery module
 $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
-#=================================================================================               
+#=================================================================================	
 
 
 # Begin MAIN script section
 #=================================================================================
 #Get the Listener from QueueManager
-$Lcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display listener(*) | runmqsc $QueueManagerName'"
-$Lout = Invoke-Expression "$Lcmd"
+$Lcmd = "cmd /c 'echo Display listener(*) | runmqsc $QueueManagerName'"
 
+$Lout = Invoke-Expression $Lcmd
 FOREACH ($LLine in $Lout)
 {
   $Lmatch = $LLine | Select-String -Pattern 'LISTENER\(' -CaseSensitive
@@ -1789,7 +1791,7 @@ FOREACH ($LLine in $Lout)
     $instance.AddProperty("$MPElement[Name='Windows!Microsoft.Windows.Computer']/PrincipalName$",$ComputerName)
     $instance.AddProperty("$MPElement[Name='IBM.MQ.QueueManager']/QueueManagerName$",$QueueManagerName)
     $instance.AddProperty("$MPElement[Name='IBM.MQ.Listener']/ListenerName$",$ListenerName)
-    $instance.AddProperty("$MPElement[Name='IBM.MQ.Listener']/QueueManagerName$",$QueueManagerName)               
+    $instance.AddProperty("$MPElement[Name='IBM.MQ.Listener']/QueueManagerName$",$QueueManagerName)	
     $instance.AddProperty("$MPElement[Name='System!System.Entity']/DisplayName$",$ListenerName)
     $DiscoveryData.AddInstance($instance)
   }
@@ -1812,55 +1814,51 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 #=================================================================================
 # End of script
 </ScriptBody>
-          <Parameters>
-            <Parameter>
-              <Name>SourceID</Name>
-              <Value>$MPElement$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>ManagedEntityID</Name>
-              <Value>$Target/Id$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>ComputerName</Name>
-              <Value>$Target/Host/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>QueueManagerName</Name>
-              <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>InstallPath</Name>
-              <Value>$Target/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
-            </Parameter>
-          </Parameters>
-          <TimeoutSeconds>300</TimeoutSeconds>
-        </DataSource>
-      </Discovery>
-      <Discovery ID="IBM.MQ.Queue.Discovery" Enabled="true" Target="IBM.MQ.QueueManager" ConfirmDelivery="false" Remotable="true" Priority="Normal">
-        <Category>Discovery</Category>
-        <DiscoveryTypes>
-          <DiscoveryClass TypeID="IBM.MQ.Queue">
-            <Property TypeID="IBM.MQ.Queue" PropertyID="QueueName" />
-            <Property TypeID="IBM.MQ.Queue" PropertyID="QueueManagerName" />
-            <Property TypeID="IBM.MQ.Queue" PropertyID="TYPE" />
-            <Property TypeID="IBM.MQ.Queue" PropertyID="DESCR" />
-            <Property TypeID="IBM.MQ.Queue" PropertyID="MAXDEPTH" />
-            <Property TypeID="IBM.MQ.Queue" PropertyID="MAXMSGL" />
-          </DiscoveryClass>
-        </DiscoveryTypes>
-        <DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
-          <IntervalSeconds>86401</IntervalSeconds>
-          <SyncTime />
-          <ScriptName>IBM.MQ.Queue.Discovery.ps1</ScriptName>
-          <ScriptBody>
+				  <Parameters>
+					<Parameter>
+					  <Name>SourceID</Name>
+					  <Value>$MPElement$</Value>
+					</Parameter>
+					<Parameter>
+					  <Name>ManagedEntityID</Name>
+					  <Value>$Target/Id$</Value>
+					</Parameter>
+					<Parameter>
+					  <Name>ComputerName</Name>
+					  <Value>$Target/Host/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+					</Parameter>
+					<Parameter>
+					  <Name>QueueManagerName</Name>
+					  <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
+					</Parameter>					
+				  </Parameters>
+				  <TimeoutSeconds>300</TimeoutSeconds>
+				</DataSource>				
+			</Discovery>
+			<Discovery ID="IBM.MQ.Queue.Discovery" Enabled="true" Target="IBM.MQ.QueueManager" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+				<Category>Discovery</Category>
+				<DiscoveryTypes>
+					<DiscoveryClass TypeID="IBM.MQ.Queue">
+						<Property TypeID="IBM.MQ.Queue" PropertyID="QueueName" />
+						<Property TypeID="IBM.MQ.Queue" PropertyID="QueueManagerName" />
+						<Property TypeID="IBM.MQ.Queue" PropertyID="TYPE" />
+						<Property TypeID="IBM.MQ.Queue" PropertyID="DESCR" />
+						<Property TypeID="IBM.MQ.Queue" PropertyID="MAXDEPTH" />
+						<Property TypeID="IBM.MQ.Queue" PropertyID="MAXMSGL" />						
+					</DiscoveryClass>
+				</DiscoveryTypes>
+				<DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
+				  <IntervalSeconds>86401</IntervalSeconds>
+				  <SyncTime />
+				  <ScriptName>IBM.MQ.Queue.Discovery.ps1</ScriptName>
+				  <ScriptBody>
 #=================================================================================
 #  IBM MQ Queue Discovery Script
 #
 #  Author: Kevin Holman
 #  v1.5
 #=================================================================================
-param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName,$InstallPath)
+param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName)
 
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
@@ -1894,19 +1892,19 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #Log script event that we are starting task
 $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript is starting. `nRunning as ($whoami).")
 #=================================================================================
-                                            
+			
 
 # Discovery Script section - Discovery scripts get this
 #=================================================================================
 # Load SCOM Discovery module
 $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
-#=================================================================================               
+#=================================================================================	
 
 
 # Begin MAIN script section
 #=================================================================================
   #Get the queues from QueueManager
-  $Qcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display QL(*) | runmqsc $QueueManagerName'"
+  $Qcmd = "cmd /c 'echo Display QL(*) | runmqsc $QueueManagerName'"
   # Write-Host "Getting Queues from ($QueueManagerName) using $Qcmd"
   $Qout = Invoke-Expression $Qcmd
   
@@ -1937,9 +1935,7 @@ $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
       {
         #Get Queue Properties
         $QPropcmd = "cmd /c `"echo Display Queue ('$QueueName') TYPE DESCR MAXDEPTH MAXMSGL | runmqsc $QueueManagerName`""
-        Set-Location "$($InstallPath)\bin"
-                              $QPropout = . "$QPropcmd"
-                              
+        $QPropout = Invoke-Expression $QPropcmd
 
         FOREACH ($QPropLine in $QPropout)
         {
@@ -2028,52 +2024,48 @@ $EndTime = Get-Date
 $ScriptTime = ($EndTime - $StartTime).TotalSeconds
 $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Runtime: ($ScriptTime) seconds.")
 #=================================================================================
-# End of script                                                  
+# End of script				  
 </ScriptBody>
-          <Parameters>
-            <Parameter>
-              <Name>SourceID</Name>
-              <Value>$MPElement$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>ManagedEntityID</Name>
-              <Value>$Target/Id$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>ComputerName</Name>
-              <Value>$Target/Host/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>QueueManagerName</Name>
-              <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>InstallPath</Name>
-              <Value>$Target/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
-            </Parameter>
-          </Parameters>
-          <TimeoutSeconds>300</TimeoutSeconds>
-        </DataSource>
-      </Discovery>
-      <Discovery ID="IBM.MQ.QueueManager.Discovery" Enabled="true" Target="IBM.MQ.Server" ConfirmDelivery="false" Remotable="true" Priority="Normal">
-        <Category>Discovery</Category>
-        <DiscoveryTypes>
-          <DiscoveryClass TypeID="IBM.MQ.QueueManager">
-            <Property TypeID="IBM.MQ.QueueManager" PropertyID="QueueManagerName" />
-          </DiscoveryClass>
-        </DiscoveryTypes>
-        <DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
-          <IntervalSeconds>86400</IntervalSeconds>
-          <SyncTime />
-          <ScriptName>IBM.MQ.QueueManager.Discovery.ps1</ScriptName>
-          <ScriptBody>
+				  <Parameters>
+					<Parameter>
+					  <Name>SourceID</Name>
+					  <Value>$MPElement$</Value>
+					</Parameter>
+					<Parameter>
+					  <Name>ManagedEntityID</Name>
+					  <Value>$Target/Id$</Value>
+					</Parameter>
+					<Parameter>
+					  <Name>ComputerName</Name>
+					  <Value>$Target/Host/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+					</Parameter>
+					<Parameter>
+					  <Name>QueueManagerName</Name>
+					  <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
+					</Parameter>					
+				  </Parameters>
+				  <TimeoutSeconds>300</TimeoutSeconds>
+				</DataSource>				
+			</Discovery>			
+			<Discovery ID="IBM.MQ.QueueManager.Discovery" Enabled="true" Target="IBM.MQ.Server" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+				<Category>Discovery</Category>
+				<DiscoveryTypes>
+					<DiscoveryClass TypeID="IBM.MQ.QueueManager">
+						<Property TypeID="IBM.MQ.QueueManager" PropertyID="QueueManagerName" />
+					</DiscoveryClass>
+				</DiscoveryTypes>
+				<DataSource ID="DS" TypeID="Windows!Microsoft.Windows.TimedPowerShell.DiscoveryProvider">
+				  <IntervalSeconds>86400</IntervalSeconds>
+				  <SyncTime />
+				  <ScriptName>IBM.MQ.QueueManager.Discovery.ps1</ScriptName>
+				  <ScriptBody>
 #=================================================================================
 #  Discover IBM MQ QueueManager
 #
 #  Author: Kevin Holman
 #  v1.1
 #=================================================================================
-param($SourceId,$ManagedEntityId,$ComputerName,$InstallPath)
+param($SourceId,$ManagedEntityId,$ComputerName)
 
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
@@ -2104,20 +2096,20 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #Log script event that we are starting task
 $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script is starting. `n Running as ($whoami).")
 #=================================================================================
-                                            
+			
 
 # Discovery Script section - Discovery scripts get this
 #=================================================================================
 # Load SCOM Discovery module
 $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
-#=================================================================================               
+#=================================================================================	
 
 
 # Begin MAIN script section
 #=================================================================================
 #Get the Queue Managers
 $QMGRcmd = "dspmq"
-$QMGRcmdOut = . "$($InstallPath)\bin\$QMGRcmd"
+$QMGRcmdOut = Invoke-Expression $QMGRcmd
 FOREACH ($QMGRLine in $QMGRcmdOut)
 {
   $QMGRLineSplit = $QMGRLine.Split("(,)")
@@ -2148,748 +2140,734 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 #=================================================================================
 # End of script
 </ScriptBody>
-          <Parameters>
-            <Parameter>
-              <Name>SourceID</Name>
-              <Value>$MPElement$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>ManagedEntityID</Name>
-              <Value>$Target/Id$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>ComputerName</Name>
-              <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
-            </Parameter>
-            <Parameter>
-              <Name>InstallPath</Name>
-              <Value>$Target/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
-            </Parameter>
-          </Parameters>
-          <TimeoutSeconds>300</TimeoutSeconds>
-        </DataSource>
-      </Discovery>
-      <Discovery ID="IBM.MQ.Server.Discovery" Enabled="true" Target="Windows!Microsoft.Windows.Server.OperatingSystem" ConfirmDelivery="false" Remotable="true" Priority="Normal">
-        <Category>Discovery</Category>
-        <DiscoveryTypes>
-          <DiscoveryClass TypeID="IBM.MQ.Server">
-            <Property TypeID="IBM.MQ.Server" PropertyID="Version" />
-            <Property TypeID="IBM.MQ.Server" PropertyID="InstallPath" />
-          </DiscoveryClass>
-        </DiscoveryTypes>
-        <DataSource ID="DS" TypeID="Windows!Microsoft.Windows.FilteredRegistryDiscoveryProvider">
-          <ComputerName>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/NetworkName$</ComputerName>
-          <RegistryAttributeDefinitions>
-            <RegistryAttributeDefinition>
-              <AttributeName>MQ_ServiceExists</AttributeName>
-              <Path>SYSTEM\CurrentControlSet\Services\MQ_Installation1</Path>
-              <PathType>0</PathType>
-              <AttributeType>0</AttributeType>
-            </RegistryAttributeDefinition>
-            <RegistryAttributeDefinition>
-              <AttributeName>MQ_Version</AttributeName>
-              <Path>SOFTWARE\IBM\WebSphere MQ\Installation\Installation1\VRMF</Path>
-              <PathType>1</PathType>
-              <AttributeType>1</AttributeType>
-            </RegistryAttributeDefinition>
-            <RegistryAttributeDefinition>
-              <AttributeName>MQ_InstallPath</AttributeName>
-              <Path>SOFTWARE\IBM\WebSphere MQ\Installation\Installation1\FilePath</Path>
-              <PathType>1</PathType>
-              <AttributeType>1</AttributeType>
-            </RegistryAttributeDefinition>
-          </RegistryAttributeDefinitions>
-          <Frequency>14400</Frequency>
-          <ClassId>$MPElement[Name="IBM.MQ.Server"]$</ClassId>
-          <InstanceSettings>
-            <Settings>
-              <Setting>
-                <Name>$MPElement[Name="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Name>
-                <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
-              </Setting>
-              <Setting>
-                <Name>$MPElement[Name="System!System.Entity"]/DisplayName$</Name>
-                <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
-              </Setting>
-              <Setting>
-                <Name>$MPElement[Name="IBM.MQ.Server"]/Version$</Name>
-                <Value>$Data/Values/MQ_Version$</Value>
-              </Setting>
-              <Setting>
-                <Name>$MPElement[Name="IBM.MQ.Server"]/InstallPath$</Name>
-                <Value>$Data/Values/MQ_InstallPath$</Value>
-              </Setting>
-            </Settings>
-          </InstanceSettings>
-          <Expression>
-            <SimpleExpression>
-              <ValueExpression>
-                <XPathQuery Type="Boolean">Values/MQ_ServiceExists</XPathQuery>
-              </ValueExpression>
-              <Operator>Equal</Operator>
-              <ValueExpression>
-                <Value Type="Boolean">true</Value>
-              </ValueExpression>
-            </SimpleExpression>
-          </Expression>
-        </DataSource>
-      </Discovery>
-    </Discoveries>
-    <Rules>
-      <Rule ID="IBM.MQ.QueueDepth.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
-        <Category>PerformanceCollection</Category>
-        <DataSources>
-          <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-            <IntervalSeconds>901</IntervalSeconds>
-            <TimeoutSeconds>300</TimeoutSeconds>
-            <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-            <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-          </DataSource>
-        </DataSources>
-        <ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
-          <ObjectName>IBMMQ</ObjectName>
-          <CounterName>QueueDepth</CounterName>
-          <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
-          <Value>$Data/Property[@Name='QueueDepth']$</Value>
-        </ConditionDetection>
-        <WriteActions>
-          <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />
-          <!-- Can be optional - collect this data to the Operations Database.  -->
-          <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
-          <!-- Can be optional - collect this data to the Data Warehouse Database -->
-        </WriteActions>
-      </Rule>
-      <Rule ID="IBM.MQ.QueuePercentUsed.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
-        <Category>PerformanceCollection</Category>
-        <DataSources>
-          <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-            <IntervalSeconds>901</IntervalSeconds>
-            <TimeoutSeconds>300</TimeoutSeconds>
-            <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-            <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-          </DataSource>
-        </DataSources>
-        <ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
-          <ObjectName>IBMMQ</ObjectName>
-          <CounterName>QueuePercentUsed</CounterName>
-          <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
-          <Value>$Data/Property[@Name='QueuePercentUsed']$</Value>
-        </ConditionDetection>
-        <WriteActions>
-          <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />
-          <!-- Can be optional - collect this data to the Operations Database.  -->
-          <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
-          <!-- Can be optional - collect this data to the Data Warehouse Database -->
-        </WriteActions>
-      </Rule>
-      <Rule ID="IBM.MQ.QueueIPPROCS.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
-        <Category>PerformanceCollection</Category>
-        <DataSources>
-          <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-            <IntervalSeconds>901</IntervalSeconds>
-            <TimeoutSeconds>300</TimeoutSeconds>
-            <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-            <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-          </DataSource>
-        </DataSources>
-        <ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
-          <ObjectName>IBMMQ</ObjectName>
-          <CounterName>IPPROCS</CounterName>
-          <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
-          <Value>$Data/Property[@Name='IPPROCS']$</Value>
-        </ConditionDetection>
-        <WriteActions>
-          <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />
-          <!-- Can be optional - collect this data to the Operations Database.  -->
-          <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
-          <!-- Can be optional - collect this data to the Data Warehouse Database -->
-        </WriteActions>
-      </Rule>
-      <Rule ID="IBM.MQ.QueueOPPROCS.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
-        <Category>PerformanceCollection</Category>
-        <DataSources>
-          <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
-            <IntervalSeconds>901</IntervalSeconds>
-            <TimeoutSeconds>300</TimeoutSeconds>
-            <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-            <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-          </DataSource>
-        </DataSources>
-        <ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
-          <ObjectName>IBMMQ</ObjectName>
-          <CounterName>OPPROCS</CounterName>
-          <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
-          <Value>$Data/Property[@Name='OPPROCS']$</Value>
-        </ConditionDetection>
-        <WriteActions>
-          <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />
-          <!-- Can be optional - collect this data to the Operations Database.  -->
-          <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
-          <!-- Can be optional - collect this data to the Data Warehouse Database -->
-        </WriteActions>
-      </Rule>
-      <Rule ID="IBM.MQ.ListenerSessions.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Listener" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
-        <Category>PerformanceCollection</Category>
-        <DataSources>
-          <DataSource ID="DS" TypeID="IBM.MQ.ListenerPerformance.Filtered.DS">
-            <IntervalSeconds>904</IntervalSeconds>
-            <TimeoutSeconds>300</TimeoutSeconds>
-            <ListenerName>$Target/Property[Type="IBM.MQ.Listener"]/ListenerName$</ListenerName>
-            <QueueManagerName>$Target/Property[Type="IBM.MQ.Listener"]/QueueManagerName$</QueueManagerName>
-          </DataSource>
-        </DataSources>
-        <ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
-          <ObjectName>IBMMQ</ObjectName>
-          <CounterName>Sessions</CounterName>
-          <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='ListenerName']$</InstanceName>
-          <Value>$Data/Property[@Name='LSessionsValue']$</Value>
-        </ConditionDetection>
-        <WriteActions>
-          <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />
-          <!-- Can be optional - collect this data to the Operations Database.  -->
-          <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />
-          <!-- Can be optional - collect this data to the Data Warehouse Database -->
-        </WriteActions>
-      </Rule>
-    </Rules>
-    <Monitors>
-      <UnitMonitor ID="IBM.MQ.ChannelStatus.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Channel" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.ChannelStatus.Monitor.MonitorType" ConfirmDelivery="false">
-        <Category>AvailabilityHealth</Category>
-        <AlertSettings AlertMessage="IBM.MQ.ChannelStatus.Monitor.AlertMessage">
-          <AlertOnState>Error</AlertOnState>
-          <AutoResolve>true</AutoResolve>
-          <AlertPriority>Normal</AlertPriority>
-          <AlertSeverity>MatchMonitorHealth</AlertSeverity>
-          <AlertParameters>
-            <AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
-            <AlertParameter2>$Data/Context/Property[@Name="ChannelName"]$</AlertParameter2>
-            <AlertParameter3>$Data/Context/Property[@Name="CStatus"]$</AlertParameter3>
-          </AlertParameters>
-        </AlertSettings>
-        <OperationalStates>
-          <OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
-          <OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
-        </OperationalStates>
-        <Configuration>
-          <IntervalSeconds>903</IntervalSeconds>
-          <ChannelName>$Target/Property[Type="IBM.MQ.Channel"]/ChannelName$</ChannelName>
-          <QueueManagerName>$Target/Property[Type="IBM.MQ.Channel"]/QueueManagerName$</QueueManagerName>
-          <TimeoutSeconds>300</TimeoutSeconds>
-        </Configuration>
-      </UnitMonitor>
-      <UnitMonitor ID="IBM.MQ.QueueDepth.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Queue" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueueDepth.Monitor.MonitorType" ConfirmDelivery="false">
-        <Category>AvailabilityHealth</Category>
-        <AlertSettings AlertMessage="IBM.MQ.QueueDepth.Monitor.AlertMessage">
-          <AlertOnState>Error</AlertOnState>
-          <AutoResolve>true</AutoResolve>
-          <AlertPriority>Normal</AlertPriority>
-          <AlertSeverity>MatchMonitorHealth</AlertSeverity>
-          <AlertParameters>
-            <AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
-            <AlertParameter2>$Data/Context/Property[@Name="QueueName"]$</AlertParameter2>
-            <AlertParameter3>$Data/Context/Property[@Name="QueueDepth"]$</AlertParameter3>
-          </AlertParameters>
-        </AlertSettings>
-        <OperationalStates>
-          <OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
-          <OperationalState ID="Warning" MonitorTypeStateID="Warning" HealthState="Warning" />
-          <OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
-        </OperationalStates>
-        <Configuration>
-          <IntervalSeconds>901</IntervalSeconds>
-          <TimeoutSeconds>300</TimeoutSeconds>
-          <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-          <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-          <WarningThreshold>10</WarningThreshold>
-          <CriticalThreshold>50</CriticalThreshold>
-        </Configuration>
-      </UnitMonitor>
-      <UnitMonitor ID="IBM.MQ.QueuePercentUsed.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Queue" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueuePercentUsed.Monitor.MonitorType" ConfirmDelivery="false">
-        <Category>AvailabilityHealth</Category>
-        <AlertSettings AlertMessage="IBM.MQ.QueuePercentUsed.Monitor.AlertMessage">
-          <AlertOnState>Error</AlertOnState>
-          <AutoResolve>true</AutoResolve>
-          <AlertPriority>Normal</AlertPriority>
-          <AlertSeverity>MatchMonitorHealth</AlertSeverity>
-          <AlertParameters>
-            <AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
-            <AlertParameter2>$Data/Context/Property[@Name="QueueName"]$</AlertParameter2>
-            <AlertParameter3>$Data/Context/Property[@Name="QueueDepth"]$</AlertParameter3>
-            <AlertParameter4>$Data/Context/Property[@Name="QueuePercentUsed"]$</AlertParameter4>
-          </AlertParameters>
-        </AlertSettings>
-        <OperationalStates>
-          <OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
-          <OperationalState ID="Warning" MonitorTypeStateID="Warning" HealthState="Warning" />
-          <OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
-        </OperationalStates>
-        <Configuration>
-          <IntervalSeconds>901</IntervalSeconds>
-          <TimeoutSeconds>300</TimeoutSeconds>
-          <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-          <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-          <WarningThreshold>50</WarningThreshold>
-          <CriticalThreshold>75</CriticalThreshold>
-        </Configuration>
-      </UnitMonitor>
-      <UnitMonitor ID="IBM.MQ.ListenerStatus.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Listener" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.ListenerStatus.Monitor.MonitorType" ConfirmDelivery="false">
-        <Category>AvailabilityHealth</Category>
-        <AlertSettings AlertMessage="IBM.MQ.ListenerStatus.Monitor.AlertMessage">
-          <AlertOnState>Error</AlertOnState>
-          <AutoResolve>true</AutoResolve>
-          <AlertPriority>Normal</AlertPriority>
-          <AlertSeverity>MatchMonitorHealth</AlertSeverity>
-          <AlertParameters>
-            <AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
-            <AlertParameter2>$Data/Context/Property[@Name="ListenerName"]$</AlertParameter2>
-            <AlertParameter3>$Data/Context/Property[@Name="LStatus"]$</AlertParameter3>
-          </AlertParameters>
-        </AlertSettings>
-        <OperationalStates>
-          <OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
-          <OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
-        </OperationalStates>
-        <Configuration>
-          <IntervalSeconds>902</IntervalSeconds>
-          <ListenerName>$Target/Property[Type="IBM.MQ.Listener"]/ListenerName$</ListenerName>
-          <QueueManagerName>$Target/Property[Type="IBM.MQ.Listener"]/QueueManagerName$</QueueManagerName>
-          <TimeoutSeconds>300</TimeoutSeconds>
-        </Configuration>
-      </UnitMonitor>
-      <UnitMonitor ID="IBM.MQ.MQ_Installation1.Service.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Server" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="Windows!Microsoft.Windows.CheckNTServiceStateMonitorType" ConfirmDelivery="false">
-        <Category>AvailabilityHealth</Category>
-        <AlertSettings AlertMessage="IBM.MQ.MQ_Installation1.Service.Monitor.AlertMessage">
-          <AlertOnState>Error</AlertOnState>
-          <AutoResolve>true</AutoResolve>
-          <AlertPriority>High</AlertPriority>
-          <AlertSeverity>Error</AlertSeverity>
-          <AlertParameters>
-            <AlertParameter1>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/NetbiosComputerName$</AlertParameter1>
-          </AlertParameters>
-        </AlertSettings>
-        <OperationalStates>
-          <OperationalState ID="Running" MonitorTypeStateID="Running" HealthState="Success" />
-          <OperationalState ID="NotRunning" MonitorTypeStateID="NotRunning" HealthState="Error" />
-        </OperationalStates>
-        <Configuration>
-          <ComputerName />
-          <ServiceName>MQ_Installation1</ServiceName>
-          <CheckStartupType />
-        </Configuration>
-      </UnitMonitor>
-      <UnitMonitor ID="IBM.MQ.QueueIPPROCS.Monitor" Accessibility="Public" Enabled="false" Target="IBM.MQ.Queue" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueueIPPROCS.Monitor.MonitorType" ConfirmDelivery="false">
-        <Category>AvailabilityHealth</Category>
-        <AlertSettings AlertMessage="IBM.MQ.QueueIPPROCS.Monitor.AlertMessage">
-          <AlertOnState>Error</AlertOnState>
-          <AutoResolve>true</AutoResolve>
-          <AlertPriority>Normal</AlertPriority>
-          <AlertSeverity>MatchMonitorHealth</AlertSeverity>
-          <AlertParameters>
-            <AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
-            <AlertParameter2>$Data/Context/Property[@Name="QueueName"]$</AlertParameter2>
-            <AlertParameter3>$Data/Context/Property[@Name="IPPROCS"]$</AlertParameter3>
-          </AlertParameters>
-        </AlertSettings>
-        <OperationalStates>
-          <OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
-          <OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
-        </OperationalStates>
-        <Configuration>
-          <IntervalSeconds>901</IntervalSeconds>
-          <TimeoutSeconds>300</TimeoutSeconds>
-          <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
-          <QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
-        </Configuration>
-      </UnitMonitor>
-      <UnitMonitor ID="IBM.MQ.QueueManagerStatus.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueueManagerStatus.Monitor.MonitorType" ConfirmDelivery="false">
-        <Category>AvailabilityHealth</Category>
-        <AlertSettings AlertMessage="IBM.MQ.QueueManagerStatus.Monitor.AlertMessage">
-          <AlertOnState>Error</AlertOnState>
-          <AutoResolve>true</AutoResolve>
-          <AlertPriority>Normal</AlertPriority>
-          <AlertSeverity>MatchMonitorHealth</AlertSeverity>
-          <AlertParameters>
-            <AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
-            <AlertParameter2>$Data/Context/Property[@Name="QMGRStatus"]$</AlertParameter2>
-          </AlertParameters>
-        </AlertSettings>
-        <OperationalStates>
-          <OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
-          <OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
-        </OperationalStates>
-        <Configuration>
-          <IntervalSeconds>904</IntervalSeconds>
-          <QueueManagerName>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</QueueManagerName>
-          <TimeoutSeconds>300</TimeoutSeconds>
-        </Configuration>
-      </UnitMonitor>
-      <DependencyMonitor ID="IBM.MQ.QueueManagerChannels.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.QueueManager.Hosts.Channel" MemberMonitor="Health!System.Health.AvailabilityState">
-        <Category>Custom</Category>
-        <Algorithm>WorstOf</Algorithm>
-        <MemberUnAvailable>Error</MemberUnAvailable>
-      </DependencyMonitor>
-      <DependencyMonitor ID="IBM.MQ.QueueManagerListeners.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.QueueManager.Hosts.Listener" MemberMonitor="Health!System.Health.AvailabilityState">
-        <Category>Custom</Category>
-        <Algorithm>WorstOf</Algorithm>
-        <MemberUnAvailable>Error</MemberUnAvailable>
-      </DependencyMonitor>
-      <DependencyMonitor ID="IBM.MQ.QueueManagerQueues.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.QueueManager.Hosts.Queue" MemberMonitor="Health!System.Health.AvailabilityState">
-        <Category>Custom</Category>
-        <Algorithm>WorstOf</Algorithm>
-        <MemberUnAvailable>Error</MemberUnAvailable>
-      </DependencyMonitor>
-      <DependencyMonitor ID="IBM.MQ.QueueManagerToServer.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Server" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.Server.Hosts.QueueManager" MemberMonitor="Health!System.Health.AvailabilityState">
-        <Category>Custom</Category>
-        <Algorithm>WorstOf</Algorithm>
-        <MemberUnAvailable>Error</MemberUnAvailable>
-      </DependencyMonitor>
-    </Monitors>
-  </Monitoring>
-  <Presentation>
-    <Views>
-      <View ID="IBM.MQ.Channel.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Channel" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
-        <Category>Custom</Category>
-        <Criteria />
-      </View>
-      <View ID="IBM.MQ.Listeners.Performance.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Listener" TypeID="SC!Microsoft.SystemCenter.PerformanceViewType" Visible="true">
-        <Category>Custom</Category>
-        <Criteria />
-      </View>
-      <View ID="IBM.MQ.Listener.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Listener" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
-        <Category>Custom</Category>
-        <Criteria />
-      </View>
-      <View ID="IBM.MQ.QueueManager.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.QueueManager" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
-        <Category>Custom</Category>
-        <Criteria />
-      </View>
-      <View ID="IBM.MQ.Queue.Performance.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Queue" TypeID="SC!Microsoft.SystemCenter.PerformanceViewType" Visible="true">
-        <Category>Custom</Category>
-        <Criteria />
-      </View>
-      <View ID="IBM.MQ.Queue.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Queue" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
-        <Category>Custom</Category>
-        <Criteria />
-      </View>
-      <View ID="IBM.MQ.Server.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Server" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
-        <Category>Custom</Category>
-        <Criteria />
-      </View>
-      <View ID="IBM.MQ.Server.Alert.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Server" TypeID="SC!Microsoft.SystemCenter.AlertViewType" Visible="true">
-        <Category>Custom</Category>
-        <Criteria>
-          <ResolutionState>
-            <StateRange Operator="NotEquals">255</StateRange>
-          </ResolutionState>
-        </Criteria>
-      </View>
-    </Views>
-    <Folders>
-      <Folder ID="IBM.MQ.Channel.Folder" Accessibility="Internal" ParentFolder="IBM.MQ.Root.Folder" />
-      <Folder ID="IBM.MQ.Root.Folder" Accessibility="Internal" ParentFolder="SC!Microsoft.SystemCenter.Monitoring.ViewFolder.Root" />
-      <Folder ID="IBM.MQ.Listener.Folder" Accessibility="Internal" ParentFolder="IBM.MQ.Root.Folder" />
-      <Folder ID="IBM.MQ.Queues.Folder" Accessibility="Internal" ParentFolder="IBM.MQ.Root.Folder" />
-    </Folders>
-    <FolderItems>
-      <FolderItem ElementID="IBM.MQ.Channel.State.View" ID="IBM.MQ.Channel.State.View.FolderItem" Folder="IBM.MQ.Channel.Folder" />
-      <FolderItem ElementID="IBM.MQ.Listeners.Performance.View" ID="IBM.MQ.Listeners.Performance.View.FolderItem" Folder="IBM.MQ.Listener.Folder" />
-      <FolderItem ElementID="IBM.MQ.Listener.State.View" ID="IBM.MQ.Listener.State.View.FolderItem" Folder="IBM.MQ.Listener.Folder" />
-      <FolderItem ElementID="IBM.MQ.QueueManager.State.View" ID="IBM.MQ.QueueManager.State.View.FolderItem" Folder="IBM.MQ.Root.Folder" />
-      <FolderItem ElementID="IBM.MQ.Queue.Performance.View" ID="IBM.MQ.Queue.Performance.View.FolderItem" Folder="IBM.MQ.Queues.Folder" />
-      <FolderItem ElementID="IBM.MQ.Queue.State.View" ID="IBM.MQ.Queue.State.View.FolderItem" Folder="IBM.MQ.Queues.Folder" />
-      <FolderItem ElementID="IBM.MQ.Server.State.View" ID="IBM.MQ.Server.State.View.FolderItem" Folder="IBM.MQ.Root.Folder" />
-      <FolderItem ElementID="IBM.MQ.Server.Alert.View" ID="IBM.MQ.Server.Alert.View.FolderItem" Folder="IBM.MQ.Root.Folder" />
-    </FolderItems>
-    <StringResources>
-      <StringResource ID="IBM.MQ.ChannelStatus.Monitor.AlertMessage" />
-      <StringResource ID="IBM.MQ.ListenerStatus.Monitor.AlertMessage" />
-      <StringResource ID="IBM.MQ.MQ_Installation1.Service.Monitor.AlertMessage" />
-      <StringResource ID="IBM.MQ.QueueManagerStatus.Monitor.AlertMessage" />
-      <StringResource ID="IBM.MQ.QueueDepth.Monitor.AlertMessage" />
-      <StringResource ID="IBM.MQ.QueuePercentUsed.Monitor.AlertMessage" />
-      <StringResource ID="IBM.MQ.QueueIPPROCS.Monitor.AlertMessage" />
-    </StringResources>
-  </Presentation>
-  <LanguagePacks>
-    <LanguagePack ID="ENU" IsDefault="true">
-      <DisplayStrings>
-        <DisplayString ElementID="IBM.MQ">
-          <Name>IBM MQ</Name>
-          <Description>IBM WebSphere MQ Management Pack</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Channel">
-          <Name>Channel</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Channel.Discovery">
-          <Name>IBM MQ Channel Discovery</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Channel.Folder">
-          <Name>Channels</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Channel.State.View">
-          <Name>Channel State</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Channel" SubElementID="ChannelName">
-          <Name>Channel Name</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Channel" SubElementID="ChannelType">
-          <Name>Channel Type</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Channel" SubElementID="QueueManagerName">
-          <Name>Queue Manager Name</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor">
-          <Name>IBM MQ Channel Status Monitor</Name>
-          <Description></Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor.AlertMessage">
-          <Name>IBM MQ Channel Status Alert</Name>
-          <Description>IBM MQ Channel Status is not Running.
+				  <Parameters>
+					<Parameter>
+					  <Name>SourceID</Name>
+					  <Value>$MPElement$</Value>
+					</Parameter>
+					<Parameter>
+					  <Name>ManagedEntityID</Name>
+					  <Value>$Target/Id$</Value>
+					</Parameter>
+					<Parameter>
+					  <Name>ComputerName</Name>
+					  <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+					</Parameter>
+				  </Parameters>
+				  <TimeoutSeconds>300</TimeoutSeconds>
+				</DataSource>				
+			</Discovery>
+			<Discovery ID="IBM.MQ.Server.Discovery" Enabled="true" Target="Windows!Microsoft.Windows.Server.OperatingSystem" ConfirmDelivery="false" Remotable="true" Priority="Normal">
+				<Category>Discovery</Category>
+				<DiscoveryTypes>
+					<DiscoveryClass TypeID="IBM.MQ.Server">
+						<Property TypeID="IBM.MQ.Server" PropertyID="Version" />
+						<Property TypeID="IBM.MQ.Server" PropertyID="InstallPath" />
+					</DiscoveryClass>					
+				</DiscoveryTypes>
+				<DataSource ID="DS" TypeID="Windows!Microsoft.Windows.FilteredRegistryDiscoveryProvider">
+					<ComputerName>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/NetworkName$</ComputerName>
+					<RegistryAttributeDefinitions>
+						<RegistryAttributeDefinition>
+							<AttributeName>MQ_ServiceExists</AttributeName>
+							<Path>SYSTEM\CurrentControlSet\Services\MQ_Installation1</Path>
+							<PathType>0</PathType>
+							<AttributeType>0</AttributeType>
+						</RegistryAttributeDefinition>
+						<RegistryAttributeDefinition>
+							<AttributeName>MQ_Version</AttributeName>
+							<Path>SOFTWARE\IBM\WebSphere MQ\Installation\Installation1\VRMF</Path>
+							<PathType>1</PathType>
+							<AttributeType>1</AttributeType>
+						</RegistryAttributeDefinition>
+						<RegistryAttributeDefinition>
+							<AttributeName>MQ_InstallPath</AttributeName>
+							<Path>SOFTWARE\IBM\WebSphere MQ\Installation\Installation1\FilePath</Path>
+							<PathType>1</PathType>
+							<AttributeType>1</AttributeType>
+						</RegistryAttributeDefinition>						
+					</RegistryAttributeDefinitions>
+					<Frequency>14400</Frequency>
+					<ClassId>$MPElement[Name="IBM.MQ.Server"]$</ClassId>
+					<InstanceSettings>
+						<Settings>
+							<Setting>
+								<Name>$MPElement[Name="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Name>
+								<Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+							</Setting>
+							<Setting>
+								<Name>$MPElement[Name="System!System.Entity"]/DisplayName$</Name>
+								<Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
+							</Setting>
+							<Setting>
+								<Name>$MPElement[Name="IBM.MQ.Server"]/Version$</Name>
+								<Value>$Data/Values/MQ_Version$</Value>
+							</Setting>
+							<Setting>
+								<Name>$MPElement[Name="IBM.MQ.Server"]/InstallPath$</Name>
+								<Value>$Data/Values/MQ_InstallPath$</Value>
+							</Setting>							
+						</Settings>
+					</InstanceSettings>
+					<Expression>
+						<SimpleExpression>
+							<ValueExpression>
+								<XPathQuery Type="Boolean">Values/MQ_ServiceExists</XPathQuery>
+							</ValueExpression>
+							<Operator>Equal</Operator>
+							<ValueExpression>
+								<Value Type="Boolean">true</Value>
+							</ValueExpression>
+						</SimpleExpression>
+					</Expression>
+				</DataSource>
+			</Discovery>
+		</Discoveries>
+		<Rules>
+		  <Rule ID="IBM.MQ.QueueDepth.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+			<Category>PerformanceCollection</Category>
+			<DataSources>
+			  <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
+				<IntervalSeconds>901</IntervalSeconds>
+				<TimeoutSeconds>300</TimeoutSeconds>
+				<QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+				<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+			  </DataSource>
+			</DataSources>
+			<ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
+			  <ObjectName>IBMMQ</ObjectName>
+			  <CounterName>QueueDepth</CounterName>
+			  <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
+			  <Value>$Data/Property[@Name='QueueDepth']$</Value>
+			</ConditionDetection>
+			<WriteActions>
+			  <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />  <!-- Can be optional - collect this data to the Operations Database.  -->
+			  <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />  <!-- Can be optional - collect this data to the Data Warehouse Database -->
+			</WriteActions>
+		  </Rule>
+		  <Rule ID="IBM.MQ.QueuePercentUsed.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+			<Category>PerformanceCollection</Category>
+			<DataSources>
+			  <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
+				<IntervalSeconds>901</IntervalSeconds>
+				<TimeoutSeconds>300</TimeoutSeconds>
+				<QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+				<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+			  </DataSource>
+			</DataSources>
+			<ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
+			  <ObjectName>IBMMQ</ObjectName>
+			  <CounterName>QueuePercentUsed</CounterName>
+			  <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
+			  <Value>$Data/Property[@Name='QueuePercentUsed']$</Value>
+			</ConditionDetection>
+			<WriteActions>
+			  <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />  <!-- Can be optional - collect this data to the Operations Database.  -->
+			  <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />  <!-- Can be optional - collect this data to the Data Warehouse Database -->
+			</WriteActions>
+		  </Rule>		  
+		  <Rule ID="IBM.MQ.QueueIPPROCS.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+			<Category>PerformanceCollection</Category>
+			<DataSources>
+			  <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
+				<IntervalSeconds>901</IntervalSeconds>
+				<TimeoutSeconds>300</TimeoutSeconds>
+				<QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+				<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+			  </DataSource>
+			</DataSources>
+			<ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
+			  <ObjectName>IBMMQ</ObjectName>
+			  <CounterName>IPPROCS</CounterName>
+			  <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
+			  <Value>$Data/Property[@Name='IPPROCS']$</Value>
+			</ConditionDetection>
+			<WriteActions>
+			  <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />  <!-- Can be optional - collect this data to the Operations Database.  -->
+			  <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />  <!-- Can be optional - collect this data to the Data Warehouse Database -->
+			</WriteActions>
+		  </Rule>
+		  <Rule ID="IBM.MQ.QueueOPPROCS.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Queue" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+			<Category>PerformanceCollection</Category>
+			<DataSources>
+			  <DataSource ID="DS" TypeID="IBM.MQ.QueuePerformance.Filtered.DS">
+				<IntervalSeconds>901</IntervalSeconds>
+				<TimeoutSeconds>300</TimeoutSeconds>
+				<QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+				<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+			  </DataSource>
+			</DataSources>
+			<ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
+			  <ObjectName>IBMMQ</ObjectName>
+			  <CounterName>OPPROCS</CounterName>
+			  <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='QueueName']$</InstanceName>
+			  <Value>$Data/Property[@Name='OPPROCS']$</Value>
+			</ConditionDetection>
+			<WriteActions>
+			  <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />  <!-- Can be optional - collect this data to the Operations Database.  -->
+			  <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />  <!-- Can be optional - collect this data to the Data Warehouse Database -->
+			</WriteActions>
+		  </Rule>
+		  <Rule ID="IBM.MQ.ListenerSessions.PerformanceCollection.Rule" Enabled="true" Target="IBM.MQ.Listener" ConfirmDelivery="false" Remotable="true" Priority="Normal" DiscardLevel="100">
+			<Category>PerformanceCollection</Category>
+			<DataSources>
+			  <DataSource ID="DS" TypeID="IBM.MQ.ListenerPerformance.Filtered.DS">
+				<IntervalSeconds>904</IntervalSeconds>
+				<TimeoutSeconds>300</TimeoutSeconds>
+				<ListenerName>$Target/Property[Type="IBM.MQ.Listener"]/ListenerName$</ListenerName>
+				<QueueManagerName>$Target/Property[Type="IBM.MQ.Listener"]/QueueManagerName$</QueueManagerName>
+			  </DataSource>
+			</DataSources>
+			<ConditionDetection ID="System.Performance.DataGenericMapper" TypeID="Perf!System.Performance.DataGenericMapper">
+			  <ObjectName>IBMMQ</ObjectName>
+			  <CounterName>Sessions</CounterName>
+			  <InstanceName>$Data/Property[@Name='QueueManagerName']$_$Data/Property[@Name='ListenerName']$</InstanceName>
+			  <Value>$Data/Property[@Name='LSessionsValue']$</Value>
+			</ConditionDetection>
+			<WriteActions>
+			  <WriteAction ID="WriteToDB" TypeID="SC!Microsoft.SystemCenter.CollectPerformanceData" />  <!-- Can be optional - collect this data to the Operations Database.  -->
+			  <WriteAction ID="WriteToDW" TypeID="MSDL!Microsoft.SystemCenter.DataWarehouse.PublishPerformanceData" />  <!-- Can be optional - collect this data to the Data Warehouse Database -->
+			</WriteActions>
+		  </Rule>
+		</Rules>
+		<Monitors>
+			<UnitMonitor ID="IBM.MQ.ChannelStatus.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Channel" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.ChannelStatus.Monitor.MonitorType" ConfirmDelivery="false">
+				<Category>AvailabilityHealth</Category>
+				<AlertSettings AlertMessage="IBM.MQ.ChannelStatus.Monitor.AlertMessage">
+					<AlertOnState>Error</AlertOnState>
+					<AutoResolve>true</AutoResolve>
+					<AlertPriority>Normal</AlertPriority>
+					<AlertSeverity>MatchMonitorHealth</AlertSeverity>
+					<AlertParameters>
+						<AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
+						<AlertParameter2>$Data/Context/Property[@Name="ChannelName"]$</AlertParameter2>
+						<AlertParameter3>$Data/Context/Property[@Name="CStatus"]$</AlertParameter3>
+					</AlertParameters>
+				</AlertSettings>
+				<OperationalStates>
+					<OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
+					<OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
+				</OperationalStates>
+				<Configuration>
+					<IntervalSeconds>903</IntervalSeconds>
+                    <ChannelName>$Target/Property[Type="IBM.MQ.Channel"]/ChannelName$</ChannelName>
+					<QueueManagerName>$Target/Property[Type="IBM.MQ.Channel"]/QueueManagerName$</QueueManagerName>
+					<TimeoutSeconds>300</TimeoutSeconds>
+				</Configuration>
+			</UnitMonitor>			
+			<UnitMonitor ID="IBM.MQ.QueueDepth.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Queue" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueueDepth.Monitor.MonitorType" ConfirmDelivery="false">
+				<Category>AvailabilityHealth</Category>
+				<AlertSettings AlertMessage="IBM.MQ.QueueDepth.Monitor.AlertMessage">
+					<AlertOnState>Error</AlertOnState>
+					<AutoResolve>true</AutoResolve>
+					<AlertPriority>Normal</AlertPriority>
+					<AlertSeverity>MatchMonitorHealth</AlertSeverity>
+					<AlertParameters>
+						<AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
+						<AlertParameter2>$Data/Context/Property[@Name="QueueName"]$</AlertParameter2>
+						<AlertParameter3>$Data/Context/Property[@Name="QueueDepth"]$</AlertParameter3>
+					</AlertParameters>
+				</AlertSettings>
+				<OperationalStates>
+					<OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
+					<OperationalState ID="Warning" MonitorTypeStateID="Warning" HealthState="Warning" />
+					<OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
+				</OperationalStates>
+				<Configuration>
+					<IntervalSeconds>901</IntervalSeconds>
+					<TimeoutSeconds>300</TimeoutSeconds>
+                    <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+					<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+					<WarningThreshold>10</WarningThreshold>
+					<CriticalThreshold>50</CriticalThreshold>
+				</Configuration>
+			</UnitMonitor>
+			<UnitMonitor ID="IBM.MQ.QueuePercentUsed.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Queue" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueuePercentUsed.Monitor.MonitorType" ConfirmDelivery="false">
+				<Category>AvailabilityHealth</Category>
+				<AlertSettings AlertMessage="IBM.MQ.QueuePercentUsed.Monitor.AlertMessage">
+					<AlertOnState>Error</AlertOnState>
+					<AutoResolve>true</AutoResolve>
+					<AlertPriority>Normal</AlertPriority>
+					<AlertSeverity>MatchMonitorHealth</AlertSeverity>
+					<AlertParameters>
+						<AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
+						<AlertParameter2>$Data/Context/Property[@Name="QueueName"]$</AlertParameter2>
+						<AlertParameter3>$Data/Context/Property[@Name="QueueDepth"]$</AlertParameter3>
+						<AlertParameter4>$Data/Context/Property[@Name="QueuePercentUsed"]$</AlertParameter4>						
+					</AlertParameters>
+				</AlertSettings>
+				<OperationalStates>
+					<OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
+					<OperationalState ID="Warning" MonitorTypeStateID="Warning" HealthState="Warning" />
+					<OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
+				</OperationalStates>
+				<Configuration>
+					<IntervalSeconds>901</IntervalSeconds>
+					<TimeoutSeconds>300</TimeoutSeconds>
+                    <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+					<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+					<WarningThreshold>50</WarningThreshold>
+					<CriticalThreshold>75</CriticalThreshold>
+				</Configuration>
+			</UnitMonitor>			
+			<UnitMonitor ID="IBM.MQ.ListenerStatus.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Listener" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.ListenerStatus.Monitor.MonitorType" ConfirmDelivery="false">
+				<Category>AvailabilityHealth</Category>
+				<AlertSettings AlertMessage="IBM.MQ.ListenerStatus.Monitor.AlertMessage">
+					<AlertOnState>Error</AlertOnState>
+					<AutoResolve>true</AutoResolve>
+					<AlertPriority>Normal</AlertPriority>
+					<AlertSeverity>MatchMonitorHealth</AlertSeverity>
+					<AlertParameters>
+						<AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
+						<AlertParameter2>$Data/Context/Property[@Name="ListenerName"]$</AlertParameter2>
+						<AlertParameter3>$Data/Context/Property[@Name="LStatus"]$</AlertParameter3>
+					</AlertParameters>
+				</AlertSettings>
+				<OperationalStates>
+					<OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
+					<OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
+				</OperationalStates>
+				<Configuration>
+					<IntervalSeconds>902</IntervalSeconds>
+                    <ListenerName>$Target/Property[Type="IBM.MQ.Listener"]/ListenerName$</ListenerName>
+					<QueueManagerName>$Target/Property[Type="IBM.MQ.Listener"]/QueueManagerName$</QueueManagerName>
+					<TimeoutSeconds>300</TimeoutSeconds>
+				</Configuration>
+			</UnitMonitor>				
+			<UnitMonitor ID="IBM.MQ.MQ_Installation1.Service.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Server" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="Windows!Microsoft.Windows.CheckNTServiceStateMonitorType" ConfirmDelivery="false">
+				<Category>AvailabilityHealth</Category>
+				<AlertSettings AlertMessage="IBM.MQ.MQ_Installation1.Service.Monitor.AlertMessage">
+					<AlertOnState>Error</AlertOnState>
+					<AutoResolve>true</AutoResolve>
+					<AlertPriority>High</AlertPriority>
+					<AlertSeverity>Error</AlertSeverity>
+					<AlertParameters>
+						<AlertParameter1>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/NetbiosComputerName$</AlertParameter1>
+					</AlertParameters>
+				</AlertSettings>
+				<OperationalStates>
+					<OperationalState ID="Running" MonitorTypeStateID="Running" HealthState="Success" />
+					<OperationalState ID="NotRunning" MonitorTypeStateID="NotRunning" HealthState="Error" />
+				</OperationalStates>
+				<Configuration>
+					<ComputerName />
+					<ServiceName>MQ_Installation1</ServiceName>
+					<CheckStartupType />
+				</Configuration>
+			</UnitMonitor>
+			<UnitMonitor ID="IBM.MQ.QueueIPPROCS.Monitor" Accessibility="Public" Enabled="false" Target="IBM.MQ.Queue" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueueIPPROCS.Monitor.MonitorType" ConfirmDelivery="false">
+				<Category>AvailabilityHealth</Category>
+				<AlertSettings AlertMessage="IBM.MQ.QueueIPPROCS.Monitor.AlertMessage">
+					<AlertOnState>Error</AlertOnState>
+					<AutoResolve>true</AutoResolve>
+					<AlertPriority>Normal</AlertPriority>
+					<AlertSeverity>MatchMonitorHealth</AlertSeverity>
+					<AlertParameters>
+						<AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
+						<AlertParameter2>$Data/Context/Property[@Name="QueueName"]$</AlertParameter2>
+						<AlertParameter3>$Data/Context/Property[@Name="IPPROCS"]$</AlertParameter3>
+					</AlertParameters>
+				</AlertSettings>
+				<OperationalStates>
+					<OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
+					<OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
+				</OperationalStates>
+				<Configuration>
+					<IntervalSeconds>901</IntervalSeconds>
+					<TimeoutSeconds>300</TimeoutSeconds>
+                    <QueueName>$Target/Property[Type="IBM.MQ.Queue"]/QueueName$</QueueName>
+					<QueueManagerName>$Target/Property[Type="IBM.MQ.Queue"]/QueueManagerName$</QueueManagerName>
+				</Configuration>
+			</UnitMonitor>			
+			<UnitMonitor ID="IBM.MQ.QueueManagerStatus.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" TypeID="IBM.MQ.QueueManagerStatus.Monitor.MonitorType" ConfirmDelivery="false">
+				<Category>AvailabilityHealth</Category>
+				<AlertSettings AlertMessage="IBM.MQ.QueueManagerStatus.Monitor.AlertMessage">
+					<AlertOnState>Error</AlertOnState>
+					<AutoResolve>true</AutoResolve>
+					<AlertPriority>Normal</AlertPriority>
+					<AlertSeverity>MatchMonitorHealth</AlertSeverity>
+					<AlertParameters>
+						<AlertParameter1>$Data/Context/Property[@Name="QueueManagerName"]$</AlertParameter1>
+						<AlertParameter2>$Data/Context/Property[@Name="QMGRStatus"]$</AlertParameter2>
+					</AlertParameters>
+				</AlertSettings>
+				<OperationalStates>
+					<OperationalState ID="Error" MonitorTypeStateID="Error" HealthState="Error" />
+					<OperationalState ID="Success" MonitorTypeStateID="Success" HealthState="Success" />
+				</OperationalStates>
+				<Configuration>
+					<IntervalSeconds>904</IntervalSeconds>
+					<QueueManagerName>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</QueueManagerName>
+					<TimeoutSeconds>300</TimeoutSeconds>
+				</Configuration>
+			</UnitMonitor>			
+			<DependencyMonitor ID="IBM.MQ.QueueManagerChannels.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.QueueManager.Hosts.Channel" MemberMonitor="Health!System.Health.AvailabilityState">
+				<Category>Custom</Category>
+				<Algorithm>WorstOf</Algorithm>
+				<MemberUnAvailable>Error</MemberUnAvailable>
+			</DependencyMonitor>
+			<DependencyMonitor ID="IBM.MQ.QueueManagerListeners.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.QueueManager.Hosts.Listener" MemberMonitor="Health!System.Health.AvailabilityState">
+				<Category>Custom</Category>
+				<Algorithm>WorstOf</Algorithm>
+				<MemberUnAvailable>Error</MemberUnAvailable>
+			</DependencyMonitor>
+			<DependencyMonitor ID="IBM.MQ.QueueManagerQueues.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.QueueManager" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.QueueManager.Hosts.Queue" MemberMonitor="Health!System.Health.AvailabilityState">
+				<Category>Custom</Category>
+				<Algorithm>WorstOf</Algorithm>
+				<MemberUnAvailable>Error</MemberUnAvailable>
+			</DependencyMonitor>
+			<DependencyMonitor ID="IBM.MQ.QueueManagerToServer.DependencyRollup.Monitor" Accessibility="Public" Enabled="true" Target="IBM.MQ.Server" ParentMonitorID="Health!System.Health.AvailabilityState" Remotable="true" Priority="Normal" RelationshipType="IBM.MQ.Server.Hosts.QueueManager" MemberMonitor="Health!System.Health.AvailabilityState">
+				<Category>Custom</Category>
+				<Algorithm>WorstOf</Algorithm>
+				<MemberUnAvailable>Error</MemberUnAvailable>
+			</DependencyMonitor>
+		</Monitors>
+	</Monitoring>
+	<Presentation>
+		<Views>
+			<View ID="IBM.MQ.Channel.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Channel" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
+				<Category>Custom</Category>
+				<Criteria />
+			</View>
+			<View ID="IBM.MQ.Listeners.Performance.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Listener" TypeID="SC!Microsoft.SystemCenter.PerformanceViewType" Visible="true">
+				<Category>Custom</Category>
+				<Criteria />
+			</View>
+			<View ID="IBM.MQ.Listener.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Listener" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
+				<Category>Custom</Category>
+				<Criteria />
+			</View>
+			<View ID="IBM.MQ.QueueManager.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.QueueManager" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
+				<Category>Custom</Category>
+				<Criteria />
+			</View>
+			<View ID="IBM.MQ.Queue.Performance.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Queue" TypeID="SC!Microsoft.SystemCenter.PerformanceViewType" Visible="true">
+				<Category>Custom</Category>
+				<Criteria />
+			</View>
+			<View ID="IBM.MQ.Queue.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Queue" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
+				<Category>Custom</Category>
+				<Criteria />
+			</View>
+			<View ID="IBM.MQ.Server.State.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Server" TypeID="SC!Microsoft.SystemCenter.StateViewType" Visible="true">
+				<Category>Custom</Category>
+				<Criteria />
+			</View>
+			<View ID="IBM.MQ.Server.Alert.View" Accessibility="Internal" Enabled="true" Target="IBM.MQ.Server" TypeID="SC!Microsoft.SystemCenter.AlertViewType" Visible="true">
+				<Category>Custom</Category>
+				<Criteria>
+					<ResolutionState>
+						<StateRange Operator="NotEquals">255</StateRange>
+					</ResolutionState>
+				</Criteria>
+			</View>
+		</Views>
+		<Folders>
+			<Folder ID="IBM.MQ.Channel.Folder" Accessibility="Internal" ParentFolder="IBM.MQ.Root.Folder" />
+			<Folder ID="IBM.MQ.Root.Folder" Accessibility="Internal" ParentFolder="SC!Microsoft.SystemCenter.Monitoring.ViewFolder.Root" />
+			<Folder ID="IBM.MQ.Listener.Folder" Accessibility="Internal" ParentFolder="IBM.MQ.Root.Folder" />
+			<Folder ID="IBM.MQ.Queues.Folder" Accessibility="Internal" ParentFolder="IBM.MQ.Root.Folder" />
+		</Folders>
+		<FolderItems>
+			<FolderItem ElementID="IBM.MQ.Channel.State.View" ID="IBM.MQ.Channel.State.View.FolderItem" Folder="IBM.MQ.Channel.Folder" />
+			<FolderItem ElementID="IBM.MQ.Listeners.Performance.View" ID="IBM.MQ.Listeners.Performance.View.FolderItem" Folder="IBM.MQ.Listener.Folder" />
+			<FolderItem ElementID="IBM.MQ.Listener.State.View" ID="IBM.MQ.Listener.State.View.FolderItem" Folder="IBM.MQ.Listener.Folder" />
+			<FolderItem ElementID="IBM.MQ.QueueManager.State.View" ID="IBM.MQ.QueueManager.State.View.FolderItem" Folder="IBM.MQ.Root.Folder" />
+			<FolderItem ElementID="IBM.MQ.Queue.Performance.View" ID="IBM.MQ.Queue.Performance.View.FolderItem" Folder="IBM.MQ.Queues.Folder" />
+			<FolderItem ElementID="IBM.MQ.Queue.State.View" ID="IBM.MQ.Queue.State.View.FolderItem" Folder="IBM.MQ.Queues.Folder" />
+			<FolderItem ElementID="IBM.MQ.Server.State.View" ID="IBM.MQ.Server.State.View.FolderItem" Folder="IBM.MQ.Root.Folder" />
+			<FolderItem ElementID="IBM.MQ.Server.Alert.View" ID="IBM.MQ.Server.Alert.View.FolderItem" Folder="IBM.MQ.Root.Folder" />
+		</FolderItems>
+		<StringResources>
+			<StringResource ID="IBM.MQ.ChannelStatus.Monitor.AlertMessage" />
+			<StringResource ID="IBM.MQ.ListenerStatus.Monitor.AlertMessage" />
+			<StringResource ID="IBM.MQ.MQ_Installation1.Service.Monitor.AlertMessage" />
+			<StringResource ID="IBM.MQ.QueueManagerStatus.Monitor.AlertMessage" />
+			<StringResource ID="IBM.MQ.QueueDepth.Monitor.AlertMessage" />
+			<StringResource ID="IBM.MQ.QueuePercentUsed.Monitor.AlertMessage" />			
+			<StringResource ID="IBM.MQ.QueueIPPROCS.Monitor.AlertMessage" />
+		</StringResources>
+	</Presentation>
+	<LanguagePacks>
+		<LanguagePack ID="ENU" IsDefault="true">
+			<DisplayStrings>
+				<DisplayString ElementID="IBM.MQ">
+					<Name>IBM MQ</Name>
+					<Description>IBM WebSphere MQ Management Pack</Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Channel">
+					<Name>Channel</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Channel.Discovery">
+					<Name>IBM MQ Channel Discovery</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Channel.Folder">
+					<Name>Channels</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Channel.State.View">
+					<Name>Channel State</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Channel" SubElementID="ChannelName">
+					<Name>Channel Name</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Channel" SubElementID="ChannelType">
+					<Name>Channel Type</Name>
+				</DisplayString>				
+				<DisplayString ElementID="IBM.MQ.Channel" SubElementID="QueueManagerName">
+					<Name>Queue Manager Name</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor">
+					<Name>IBM MQ Channel Status Monitor</Name>
+					<Description></Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor.AlertMessage">
+					<Name>IBM MQ Channel Status Alert</Name>
+					<Description>IBM MQ Channel Status is not Running.
 Channel Status: {2}
 Channel Name: {1}
 Queue Manager Name: {0}</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor" SubElementID="Error">
-          <Name>Not Running</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor" SubElementID="Success">
-          <Name>Running or Inactive</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueDepth.Monitor">
-          <Name>IBM MQ Queue Depth Monitor</Name>
-          <Description></Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueDepth.Monitor.AlertMessage">
-          <Name>IBM MQ Queue Depth exceeds threshold</Name>
-          <Description>The current queue depth is above the threshold.
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor" SubElementID="Error">
+					<Name>Not Running</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.ChannelStatus.Monitor" SubElementID="Success">
+					<Name>Running or Inactive</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueDepth.Monitor">
+					<Name>IBM MQ Queue Depth Monitor</Name>
+					<Description></Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueDepth.Monitor.AlertMessage">
+					<Name>IBM MQ Queue Depth exceeds threshold</Name>
+					<Description>The current queue depth is above the threshold.
 Queue Depth: {2}
 Queue Name: {1}
 Queue Manager Name {0}</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueDepth.Monitor" SubElementID="Error">
-          <Name>Error</Name>
-          <Description>Error</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueDepth.Monitor" SubElementID="Success">
-          <Name>Success</Name>
-          <Description>Success</Description>
-        </DisplayString>
-       <DisplayString ElementID="IBM.MQ.QueueDepth.Monitor" SubElementID="Warning">
-          <Name>Warning</Name>
-          <Description>Warning</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueDepth.PerformanceCollection.Rule">
-          <Name>IBM MQ CurrentQueueDepth Performance Collection Rule</Name>
-          <Description></Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor">
-          <Name>IBM MQ Queue Percent Used Monitor</Name>
-          <Description></Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor.AlertMessage">
-          <Name>IBM MQ Queue Percent Used exceeds threshold</Name>
-          <Description>The current queue percent used is above the threshold.
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueDepth.Monitor" SubElementID="Error">
+					<Name>Error</Name>
+					<Description>Error</Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueDepth.Monitor" SubElementID="Success">
+					<Name>Success</Name>
+					<Description>Success</Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueDepth.Monitor" SubElementID="Warning">
+					<Name>Warning</Name>
+					<Description>Warning</Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueDepth.PerformanceCollection.Rule">
+					<Name>IBM MQ CurrentQueueDepth Performance Collection Rule</Name>
+					<Description></Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor">
+					<Name>IBM MQ Queue Percent Used Monitor</Name>
+					<Description></Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor.AlertMessage">
+					<Name>IBM MQ Queue Percent Used exceeds threshold</Name>
+					<Description>The current queue percent used is above the threshold.
 Queue Percent Used: {3}
 Queue Depth: {2}
 Queue Name: {1}
 Queue Manager Name {0}</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor" SubElementID="Error">
-          <Name>Error</Name>
-          <Description>Error</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor" SubElementID="Success">
-          <Name>Success</Name>
-          <Description>Success</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor" SubElementID="Warning">
-          <Name>Warning</Name>
-          <Description>Warning</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueuePercentUsed.PerformanceCollection.Rule">
-          <Name>IBM MQ Queue Percent Used Performance Collection Rule</Name>
-          <Description></Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Listener">
-          <Name>Listener</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Listener.Discovery">
-          <Name>IBM MQ Listener Discovery</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Listener.Folder">
-          <Name>Listeners</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Listener.State.View">
-          <Name>Listener State</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Listener" SubElementID="ListenerName">
-          <Name>Listener Name</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Listener" SubElementID="QueueManagerName">
-          <Name>Queue Manager Name</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Listeners.Performance.View">
-          <Name>Listener Performance</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.ListenerSessions.PerformanceCollection.Rule">
-          <Name>IBM MQ Listener Sessions Performance Collection Rule</Name>
-          <Description>Collect number of sessions on Listener</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor">
-          <Name>IBM MQ Listener Status Monitor</Name>
-          <Description></Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor.AlertMessage">
-          <Name>IBM MQ Listener Status is Not Running</Name>
-          <Description>IBM MQ Listener Status is not Running.
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor" SubElementID="Error">
+					<Name>Error</Name>
+					<Description>Error</Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor" SubElementID="Success">
+					<Name>Success</Name>
+					<Description>Success</Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueuePercentUsed.Monitor" SubElementID="Warning">
+					<Name>Warning</Name>
+					<Description>Warning</Description>
+				</DisplayString>				
+				<DisplayString ElementID="IBM.MQ.QueuePercentUsed.PerformanceCollection.Rule">
+					<Name>IBM MQ Queue Percent Used Performance Collection Rule</Name>
+					<Description></Description>
+				</DisplayString>				
+				<DisplayString ElementID="IBM.MQ.Listener">
+					<Name>Listener</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Listener.Discovery">
+					<Name>IBM MQ Listener Discovery</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Listener.Folder">
+					<Name>Listeners</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Listener.State.View">
+					<Name>Listener State</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Listener" SubElementID="ListenerName">
+					<Name>Listener Name</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Listener" SubElementID="QueueManagerName">
+					<Name>Queue Manager Name</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Listeners.Performance.View">
+					<Name>Listener Performance</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.ListenerSessions.PerformanceCollection.Rule">
+					<Name>IBM MQ Listener Sessions Performance Collection Rule</Name>
+					<Description>Collect number of sessions on Listener</Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor">
+					<Name>IBM MQ Listener Status Monitor</Name>
+					<Description></Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor.AlertMessage">
+					<Name>IBM MQ Listener Status is Not Running</Name>
+					<Description>IBM MQ Listener Status is not Running.
 Listener Status: {2}
 Listener Name: {1}
 Queue Manager Name: {0}</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor" SubElementID="Error">
-          <Name>Not Running</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor" SubElementID="Success">
-          <Name>Running</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor">
-          <Name>IBM MQ MQ_Installation1 Service Monitor</Name>
-          <Description></Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor.AlertMessage">
-          <Name>IBM MQ MQ_Installation1 Service is not running</Name>
-          <Description>IBM WebSphere MQ (Installation1) Service Not running on server {0}.</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor" SubElementID="NotRunning">
-          <Name>NotRunning</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor" SubElementID="Running">
-          <Name>Running</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Server.Alert.View">
-          <Name>Alerts</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Queue">
-          <Name>Queue</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Queue.Discovery">
-          <Name>IBM MQ Queue Discovery</Name>
-          <Description></Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor">
-          <Name>IBM MQ Queue IPPROCS Monitor</Name>
-          <Description></Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor" SubElementID="Error">
-          <Name>Error</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor" SubElementID="Success">
-          <Name>Success</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor.AlertMessage">
-          <Name>IBM MQ IPPROCS Monitor greater than zero</Name>
-          <Description>The current IPPROCS value is above the threshold.
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor" SubElementID="Error">
+					<Name>Not Running</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.ListenerStatus.Monitor" SubElementID="Success">
+					<Name>Running</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor">
+					<Name>IBM MQ MQ_Installation1 Service Monitor</Name>
+					<Description></Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor.AlertMessage">
+					<Name>IBM MQ MQ_Installation1 Service is not running</Name>
+					<Description>IBM WebSphere MQ (Installation1) Service Not running on server {0}.</Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor" SubElementID="NotRunning">
+					<Name>NotRunning</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.MQ_Installation1.Service.Monitor" SubElementID="Running">
+					<Name>Running</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Server.Alert.View">
+					<Name>Alerts</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Queue">
+					<Name>Queue</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Queue.Discovery">
+					<Name>IBM MQ Queue Discovery</Name>
+					<Description></Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor">
+					<Name>IBM MQ Queue IPPROCS Monitor</Name>
+					<Description></Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor" SubElementID="Error">
+					<Name>Error</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor" SubElementID="Success">
+					<Name>Success</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueIPPROCS.Monitor.AlertMessage">
+					<Name>IBM MQ IPPROCS Monitor greater than zero</Name>
+					<Description>The current IPPROCS value is above the threshold.
 IPPROCS value: {2}
 Queue Name: {1}
 Queue Manager Name {0}</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Queue.Performance.View">
-          <Name>Queue Performance</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Queue.State.View">
-          <Name>Queue State</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Queue" SubElementID="DESCR">
-          <Name>Description</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueIPPROCS.PerformanceCollection.Rule">
-          <Name>IBM MQ QueueIPPROCS Performance Collection Rule</Name>
-          <Description>Number of Applications reading from this queue</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueManager">
-          <Name>Queue Manager</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueManager.Discovery">
-          <Name>IBM MQ QueueManager Discovery</Name>
-          <Description></Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueManager.State.View">
-          <Name>Queue Managers</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueManagerChannels.DependencyRollup.Monitor">
-          <Name>IBM MQ Channels To QueueManager Dependency Rollup Monitor</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueManagerListeners.DependencyRollup.Monitor">
-          <Name>IBM MQ Listeners To QueueManager Dependency Rollup Monitor</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueManager" SubElementID="QueueManagerName">
-          <Name>Queue Manager Name</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueManagerQueues.DependencyRollup.Monitor">
-          <Name>IBM MQ Queues To QueueManager Dependency Rollup Monitor"</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor">
-          <Name>IBM MQ QueueManager Status Monitor</Name>
-          <Description></Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor.AlertMessage">
-          <Name>IBM Queue Manager Status is Not Running</Name>
-          <Description>IBM Queue Manager Status is not Running.
+                </DisplayString>			
+				<DisplayString ElementID="IBM.MQ.Queue.Performance.View">
+					<Name>Queue Performance</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Queue.State.View">
+					<Name>Queue State</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Queue" SubElementID="DESCR">
+					<Name>Description</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueIPPROCS.PerformanceCollection.Rule">
+					<Name>IBM MQ QueueIPPROCS Performance Collection Rule</Name>
+					<Description>Number of Applications reading from this queue</Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueManager">
+					<Name>Queue Manager</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueManager.Discovery">
+					<Name>IBM MQ QueueManager Discovery</Name>
+					<Description></Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueManager.State.View">
+					<Name>Queue Managers</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueManagerChannels.DependencyRollup.Monitor">
+					<Name>IBM MQ Channels To QueueManager Dependency Rollup Monitor</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueManagerListeners.DependencyRollup.Monitor">
+					<Name>IBM MQ Listeners To QueueManager Dependency Rollup Monitor</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueManager" SubElementID="QueueManagerName">
+					<Name>Queue Manager Name</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueManagerQueues.DependencyRollup.Monitor">
+					<Name>IBM MQ Queues To QueueManager Dependency Rollup Monitor"</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor">
+					<Name>IBM MQ QueueManager Status Monitor</Name>
+					<Description></Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor.AlertMessage">
+					<Name>IBM Queue Manager Status is Not Running</Name>
+					<Description>IBM Queue Manager Status is not Running.
 
 Status: {0}
 Queue Manager Name: {1}
 Host Name: {2}</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor" SubElementID="Error">
-          <Name>Error</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor" SubElementID="Success">
-          <Name>Success</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueManagerToServer.DependencyRollup.Monitor">
-          <Name>IBM MQ QueueManager To Server DependencyRollup Monitor</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Queue" SubElementID="MAXDEPTH">
-          <Name>MAXDEPTH</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Queue" SubElementID="MAXMSGL">
-          <Name>MAXMSGL</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.QueueOPPROCS.PerformanceCollection.Rule">
-          <Name>IBM MQ QueueOPPROCS Performance Collection Rule</Name>
-          <Description>Number of Applications writing on this queue</Description>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Queue" SubElementID="QueueManagerName">
-          <Name>Queue Manager Name</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Queue" SubElementID="QueueName">
-          <Name>Queue Name</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Queues.Folder">
-          <Name>Queues</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Queue" SubElementID="TYPE">
-          <Name>TYPE</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Root.Folder">
-          <Name>IBM MQ</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Server">
-          <Name>IBM MQ Server</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Server" SubElementID="Version">
-          <Name>Version</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Server" SubElementID="InstallPath">
-          <Name>InstallPath</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Server.Discovery">
-          <Name>IBM MQ Server Discovery</Name>
-        </DisplayString>
-        <DisplayString ElementID="IBM.MQ.Server.State.View">
-          <Name>MQ Server State</Name>
-        </DisplayString>
-      </DisplayStrings>
-    </LanguagePack>
-  </LanguagePacks>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor" SubElementID="Error">
+					<Name>Error</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueManagerStatus.Monitor" SubElementID="Success">
+					<Name>Success</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueManagerToServer.DependencyRollup.Monitor">
+					<Name>IBM MQ QueueManager To Server DependencyRollup Monitor</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Queue" SubElementID="MAXDEPTH">
+					<Name>MAXDEPTH</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Queue" SubElementID="MAXMSGL">
+					<Name>MAXMSGL</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.QueueOPPROCS.PerformanceCollection.Rule">
+					<Name>IBM MQ QueueOPPROCS Performance Collection Rule</Name>
+					<Description>Number of Applications writing on this queue</Description>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Queue" SubElementID="QueueManagerName">
+					<Name>Queue Manager Name</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Queue" SubElementID="QueueName">
+					<Name>Queue Name</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Queues.Folder">
+					<Name>Queues</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Queue" SubElementID="TYPE">
+					<Name>TYPE</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Root.Folder">
+					<Name>IBM MQ</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Server">
+					<Name>IBM MQ Server</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Server" SubElementID="Version">
+					<Name>Version</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Server" SubElementID="InstallPath">
+					<Name>InstallPath</Name>
+				</DisplayString>				
+				<DisplayString ElementID="IBM.MQ.Server.Discovery">
+					<Name>IBM MQ Server Discovery</Name>
+				</DisplayString>
+				<DisplayString ElementID="IBM.MQ.Server.State.View">
+					<Name>MQ Server State</Name>
+				</DisplayString>
+			</DisplayStrings>
+		</LanguagePack>
+	</LanguagePacks>
 </ManagementPack>

--- a/IBM.MQ.xml
+++ b/IBM.MQ.xml
@@ -3,7 +3,7 @@
 	<Manifest>
 		<Identity>
 			<ID>IBM.MQ</ID>
-			<Version>3.2.1.6</Version>
+			<Version>3.2.1.7</Version>
 		</Identity>
 		<Name>IBM.MQ</Name>
 		<References>
@@ -174,7 +174,7 @@
 #  Author:  Kevin Holman
 #  v1.6
 #=================================================================================
-
+param($installPath)
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
 #=================================================================================
@@ -202,11 +202,13 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #=================================================================================
 
 
+Set-WinUILanguageOverride -Language "en-US"
 # Begin MAIN script section
 #=================================================================================
 #Get the Queue Managers
-$QMGRcmd = "dspmq"
-$QMGRcmdOut = Invoke-Expression $QMGRcmd
+$QMGRcmd = "$($InstallPath)\bin\dspmq"
+$QMGRcmdOut = . "$QMGRcmd"
+
 FOREACH ($QMGRLine in $QMGRcmdOut)
 {
   $QMGRLineSplit = $QMGRLine.Split("(,)")
@@ -214,7 +216,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
   # Write-Host "Found QueueManagerName: ($QueueManagerName)"
 
   #Get the queues from each QueueManager
-  $Qcmd = "cmd /c 'echo Display QL(*) | runmqsc $QueueManagerName'"
+  $Qcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display QL(*) | runmqsc $QueueManagerName'"
 
   # Write-Host "Getting Queues from ($QM) using $Qcmd"
   $Qout = Invoke-Expression $Qcmd
@@ -228,7 +230,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
       # Write-Host "Found Queue: ($QueueName)"
 
       #Get the Queue Properties from the Queue      
-      $QPropsCmd = "cmd /c `"echo Display Queue('$QueueName') | runmqsc $QueueManagerName`""
+      $QPropsCmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display Queue($QueueName) | runmqsc $QueueManagerName'"
       $QPropsOut = Invoke-Expression $QPropsCmd
       # Loop through each line of the Queue properties and pull out any interesting data for a propertybag
       FOREACH ($QPropLine in $QPropsOut)
@@ -315,6 +317,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
 }
 #=================================================================================
 # End MAIN script section
+Set-WinUILanguageOverride
 
 
 # End of script section
@@ -327,7 +330,11 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 # End of script
                 </ScriptBody>
                 <Parameters>
-                </Parameters>				
+					<Parameter>
+						<Name>InstallPath</Name>
+						<Value>$Target/Host/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
+					</Parameter>
+				</Parameters>				
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
             </MemberModules>
@@ -427,7 +434,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #  Author:  Kevin Holman
 #  v1.1
 #=================================================================================
-
+param($installPath)
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
 #=================================================================================
@@ -455,11 +462,13 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #=================================================================================
 
 
+Set-WinUILanguageOverride -Language "en-US"
 # Begin MAIN script section
 #=================================================================================
 #Get the Queue Managers
-$QMGRcmd = "dspmq"
-$QMGRcmdOut = Invoke-Expression $QMGRcmd
+$QMGRcmd = "$($InstallPath)\bin\dspmq"
+$QMGRcmdOut = . "$QMGRcmd"
+
 FOREACH ($QMGRLine in $QMGRcmdOut)
 {
   $QMGRLineSplit = $QMGRLine.Split("(,)")
@@ -467,7 +476,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
   #Write-Host "Found QM: ($QueueManagerName)"
 
   #Get the Listeners from each QueueManager
-  $Lcmd = "cmd /c 'echo Display listener(*) | runmqsc $QueueManagerName'"
+  $Lcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display listener(*) | runmqsc $QueueManagerName'"
 
   $Lout = Invoke-Expression $Lcmd
   FOREACH ($LLine in $Lout)
@@ -481,7 +490,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
       #Write-Host "Found Listener: ($ListenerName)"
 
       #Get Listener Sessions
-      $LSessionsCmd = "cmd /c `"echo DISPLAY Listener('$ListenerName') SESSIONS | runmqsc $QueueManagerName`""
+      $LSessionsCmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo DISPLAY Listener($ListenerName) SESSIONS | runmqsc $QueueManagerName'"
       $LSessionsOut = Invoke-Expression $LSessionsCmd
 
       [int]$LSessionsValue = 0
@@ -514,6 +523,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
 }
 #=================================================================================
 # End MAIN script section
+Set-WinUILanguageOverride
 
 
 # End of script section
@@ -526,6 +536,10 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 # End of script
                 </ScriptBody>
                 <Parameters>
+					<Parameter>
+              			<Name>InstallPath</Name>
+              			<Value>$Target/Host/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
+            		</Parameter>
                 </Parameters>				
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
@@ -569,7 +583,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #  Author:  Kevin Holman
 #  v1.2
 #=================================================================================
-
+param($installPath)
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
 #=================================================================================
@@ -597,11 +611,13 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #=================================================================================
 
 
+Set-WinUILanguageOverride -Language "en-US"
 # Begin MAIN script section
 #=================================================================================
 #Get the Queue Managers
-$QMGRcmd = "dspmq"
-$QMGRcmdOut = Invoke-Expression $QMGRcmd
+$QMGRcmd = "$($InstallPath)\bin\dspmq"
+$QMGRcmdOut = . "$QMGRcmd"
+
 FOREACH ($QMGRLine in $QMGRcmdOut)
 {
   $QMGRLineSplit = $QMGRLine.Split("(,)")
@@ -609,7 +625,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
   #Write-Host "Found QM: ($QueueManagerName)"
 
   #Get the Channels from each QueueManager
-  $Ccmd = "cmd /c 'echo Display channel(*) | runmqsc $QueueManagerName'"
+  $Ccmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display channel(*) | runmqsc $QueueManagerName'"
 
   $Cout = Invoke-Expression $Ccmd
   FOREACH ($CLine in $Cout)
@@ -623,7 +639,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
       #Write-Host "Found Channel: ($ChannelName)"
 
       #Get the channel status from ChannelName
-      $CStatusCmd = "cmd /c `"echo Display chs('$ChannelName') | runmqsc $QueueManagerName`""
+      $CStatusCmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display chs($ChannelName) | runmqsc $QueueManagerName'"
       $CStatusOut = Invoke-Expression $CStatusCmd
       
       FOREACH ($CStatusLine in $CStatusOut)
@@ -661,6 +677,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
 }
 #=================================================================================
 # End MAIN script section
+Set-WinUILanguageOverride
 
 
 # End of script section
@@ -673,6 +690,10 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 # End of script
                 </ScriptBody>
                 <Parameters>
+            		<Parameter>
+			            <Name>InstallPath</Name>
+              			<Value>$Target/Host/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
+            		</Parameter>
                 </Parameters>				
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
@@ -716,7 +737,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #  Author:  Kevin Holman
 #  v1.1
 #=================================================================================
-
+param($installPath)
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
 #=================================================================================
@@ -744,11 +765,13 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #=================================================================================
 
 
+Set-WinUILanguageOverride -Language "en-US"
 # Begin MAIN script section
 #=================================================================================
 #Get the Queue Managers
-$QMGRcmd = "dspmq"
-$QMGRcmdOut = Invoke-Expression $QMGRcmd
+$QMGRcmd = "$($InstallPath)\bin\dspmq"
+$QMGRcmdOut = . "$QMGRcmd"
+
 FOREACH ($QMGRLine in $QMGRcmdOut)
 {
   $QMGRLineSplit = $QMGRLine.Split("(,)")
@@ -756,7 +779,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
   #Write-Host "Found QM: ($QueueManagerName)"
 
   #Get the Listeners from each QueueManager
-  $Lcmd = "cmd /c 'echo Display listener(*) | runmqsc $QueueManagerName'"
+  $Lcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display listener(*) | runmqsc $QueueManagerName'"
 
   $Lout = Invoke-Expression $Lcmd
   FOREACH ($LLine in $Lout)
@@ -770,7 +793,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
       #Write-Host "Found Listener: ($ListenerName)"
 
       #Get Listener Status
-      $LStatusCmd = "cmd /c `"echo DISPLAY lsstatus('$ListenerName') | runmqsc $QueueManagerName`""
+      $LStatusCmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo DISPLAY lsstatus($ListenerName) | runmqsc $QueueManagerName'"
       $LStatusOut = Invoke-Expression $LStatusCmd
 
       FOREACH ($LStatusLine in $LStatusOut)
@@ -801,6 +824,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
 }
 #=================================================================================
 # End MAIN script section
+Set-WinUILanguageOverride
 
 
 # End of script section
@@ -813,6 +837,10 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 # End of script
                 </ScriptBody>
                 <Parameters>
+            		<Parameter>
+              			<Name>InstallPath</Name>
+              			<Value>$Target/Host/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
+            		</Parameter>
                 </Parameters>				
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
@@ -856,7 +884,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #  Author:  Kevin Holman
 #  v1.0
 #=================================================================================
-
+param($installPath)
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
 #=================================================================================
@@ -883,12 +911,13 @@ $momapi = New-Object -comObject MOM.ScriptAPI
 #$momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript is starting. `nRunning as ($whoami).")
 #=================================================================================
 
-
+Set-WinUILanguageOverride -Language "en-US"
 # Begin MAIN script section
 #=================================================================================
 #Get the Queue Managers
-$QMGRcmd = "dspmq"
-$QMGRcmdOut = Invoke-Expression $QMGRcmd
+$QMGRcmd = "$($InstallPath)\bin\dspmq"
+$QMGRcmdOut = . "$QMGRcmd"
+
 FOREACH ($QMGRLine in $QMGRcmdOut)
 {
   $QMGRLineSplit = $QMGRLine.Split("(,)")
@@ -913,7 +942,7 @@ FOREACH ($QMGRLine in $QMGRcmdOut)
 }
 #=================================================================================
 # End MAIN script section
-
+Set-WinUILanguageOverride
 
 # End of script section
 #=================================================================================
@@ -925,6 +954,10 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 # End of script
                 </ScriptBody>
                 <Parameters>
+            		<Parameter>
+              			<Name>InstallPath</Name>
+              			<Value>$Target/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
+            		</Parameter>
                 </Parameters>				
                 <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
               </ProbeAction>
@@ -1599,7 +1632,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`nScript Completed. `nRunning as 
 #  Author: Kevin Holman
 #  v1.2
 #=================================================================================
-param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName)
+param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName,$InstallPath)
 
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
@@ -1640,12 +1673,13 @@ $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
 #=================================================================================	
 
 
+Set-WinUILanguageOverride -Language "en-US"
 # Begin MAIN script section
 #=================================================================================
 #Get the Channel from QueueManager
-$Ccmd = "cmd /c 'echo Display channel(*) | runmqsc $QueueManagerName'"
+$Ccmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display channel(*) | runmqsc $QueueManagerName'"
+$Cout = Invoke-Expression "$Ccmd"
 
-$Cout = Invoke-Expression $Ccmd
 FOREACH ($CLine in $Cout)
 {
   $Cmatch = $CLine | Select-String -Pattern 'CHANNEL\(' -CaseSensitive
@@ -1677,6 +1711,7 @@ $DiscoveryData
 # $momapi.Return($DiscoveryData)
 #=================================================================================
 # End MAIN script section
+Set-WinUILanguageOverride
 
 
 # End of script section
@@ -1704,6 +1739,10 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 					<Parameter>
 					  <Name>QueueManagerName</Name>
 					  <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
+					</Parameter>
+            		<Parameter>
+	              		<Name>InstallPath</Name>
+    	          		<Value>$Target/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
 					</Parameter>					
 				  </Parameters>
 				  <TimeoutSeconds>300</TimeoutSeconds>
@@ -1728,7 +1767,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 #  Author: Kevin Holman
 #  v1.1
 #=================================================================================
-param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName)
+param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName,$InstallPath)
 
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
@@ -1769,12 +1808,13 @@ $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
 #=================================================================================	
 
 
+Set-WinUILanguageOverride -Language "en-US"
 # Begin MAIN script section
 #=================================================================================
 #Get the Listener from QueueManager
-$Lcmd = "cmd /c 'echo Display listener(*) | runmqsc $QueueManagerName'"
+$Lcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display listener(*) | runmqsc $QueueManagerName'"
+$Lout = Invoke-Expression "$Lcmd"
 
-$Lout = Invoke-Expression $Lcmd
 FOREACH ($LLine in $Lout)
 {
   $Lmatch = $LLine | Select-String -Pattern 'LISTENER\(' -CaseSensitive
@@ -1803,6 +1843,7 @@ $DiscoveryData
 # $momapi.Return($DiscoveryData)
 #=================================================================================
 # End MAIN script section
+Set-WinUILanguageOverride
 
 
 # End of script section
@@ -1830,7 +1871,11 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 					<Parameter>
 					  <Name>QueueManagerName</Name>
 					  <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
-					</Parameter>					
+					</Parameter>
+            		<Parameter>
+              			<Name>InstallPath</Name>
+              			<Value>$Target/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
+            		</Parameter>					
 				  </Parameters>
 				  <TimeoutSeconds>300</TimeoutSeconds>
 				</DataSource>				
@@ -1858,7 +1903,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 #  Author: Kevin Holman
 #  v1.5
 #=================================================================================
-param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName)
+param($SourceId,$ManagedEntityId,[string]$ComputerName,[string]$QueueManagerName,$InstallPath)
 
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
@@ -1901,10 +1946,11 @@ $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
 #=================================================================================	
 
 
+Set-WinUILanguageOverride -Language "en-US"
 # Begin MAIN script section
 #=================================================================================
   #Get the queues from QueueManager
-  $Qcmd = "cmd /c 'echo Display QL(*) | runmqsc $QueueManagerName'"
+  $Qcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display QL(*) | runmqsc $QueueManagerName'"
   # Write-Host "Getting Queues from ($QueueManagerName) using $Qcmd"
   $Qout = Invoke-Expression $Qcmd
   
@@ -1934,7 +1980,7 @@ $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
       IF ($ContinueDiscovery)
       {
         #Get Queue Properties
-        $QPropcmd = "cmd /c `"echo Display Queue ('$QueueName') TYPE DESCR MAXDEPTH MAXMSGL | runmqsc $QueueManagerName`""
+        $QPropcmd = "cmd /c 'cd $($InstallPath)\bin\ &amp; echo Display Queue ($QueueName) TYPE DESCR MAXDEPTH MAXMSGL | runmqsc $QueueManagerName'"
         $QPropout = Invoke-Expression $QPropcmd
 
         FOREACH ($QPropLine in $QPropout)
@@ -2015,6 +2061,7 @@ $DiscoveryData
 # $momapi.Return($DiscoveryData)
 #=================================================================================
 # End MAIN script section
+Set-WinUILanguageOverride
 
 
 # End of script section
@@ -2042,7 +2089,11 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 					<Parameter>
 					  <Name>QueueManagerName</Name>
 					  <Value>$Target/Property[Type="IBM.MQ.QueueManager"]/QueueManagerName$</Value>
-					</Parameter>					
+					</Parameter>
+            		<Parameter>
+              			<Name>InstallPath</Name>
+              			<Value>$Target/Host/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
+            		</Parameter>					
 				  </Parameters>
 				  <TimeoutSeconds>300</TimeoutSeconds>
 				</DataSource>				
@@ -2065,7 +2116,7 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 #  Author: Kevin Holman
 #  v1.1
 #=================================================================================
-param($SourceId,$ManagedEntityId,$ComputerName)
+param($SourceId,$ManagedEntityId,$ComputerName,$InstallPath)
 
 
 # Manual Testing section - put stuff here for manually testing script - typically parameters:
@@ -2105,11 +2156,13 @@ $DiscoveryData = $momapi.CreateDiscoveryData(0, $SourceId, $ManagedEntityId)
 #=================================================================================	
 
 
+Set-WinUILanguageOverride -Language "en-US"
 # Begin MAIN script section
 #=================================================================================
 #Get the Queue Managers
-$QMGRcmd = "dspmq"
-$QMGRcmdOut = Invoke-Expression $QMGRcmd
+$QMGRcmd = "$($InstallPath)\bin\dspmq"
+$QMGRcmdOut = . "$QMGRcmd"
+
 FOREACH ($QMGRLine in $QMGRcmdOut)
 {
   $QMGRLineSplit = $QMGRLine.Split("(,)")
@@ -2129,6 +2182,7 @@ $DiscoveryData
 # $momapi.Return($DiscoveryData)
 #=================================================================================
 # End MAIN script section
+Set-WinUILanguageOverride
 
 
 # End of script section
@@ -2153,6 +2207,10 @@ $momapi.LogScriptEvent($ScriptName,$EventID,0,"`n Script Completed. `n Script Ru
 					  <Name>ComputerName</Name>
 					  <Value>$Target/Host/Property[Type="Windows!Microsoft.Windows.Computer"]/PrincipalName$</Value>
 					</Parameter>
+            		<Parameter>
+              			<Name>InstallPath</Name>
+              			<Value>$Target/Property[Type="IBM.MQ.Server"]/InstallPath$</Value>
+            		</Parameter>
 				  </Parameters>
 				  <TimeoutSeconds>300</TimeoutSeconds>
 				</DataSource>				


### PR DESCRIPTION
Added installPath from server class property as parameter in channel/listener/queue discovery to run commands even if installPath is not in env.variables.
Therefore updated the commands (including quotes because of space in "Program Files"). Dot-Executing binary command (dspmq) instead of Invoke-Express (not working here with space in path).
Added Set-WinUILanguageOverride to allow the script to run with non-"en-US" locale (in de-* for instance the channel status is "Aktiv" instead of "RUNNING"). Unfortunately, for executables it is not possible to set the culture for the thread/session and therefore it may be set temporary using Set-WinUILanguageOverride.
These changes are tested and verified.
Unsealed XML only, please seal MP with your own key.